### PR TITLE
Added github actions to check Terraform code

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -7,11 +7,10 @@ defaults:
     shell: sh
 
 jobs:
-  # Terraform init and validate configuration
-  terraform-init:
-    name: 'Terraform-init'
+  # Terraform validate configuration
+  terraform-validate:
+    name: 'Terraform-validate'
     runs-on: ubuntu-latest
-    environment: dev
     container:
       image: hashicorp/terraform:0.14.6
       env:
@@ -36,7 +35,6 @@ jobs:
   terraform-format:
     name: 'Terraform-format'
     runs-on: ubuntu-latest
-    environment: dev
     container:
       image: hashicorp/terraform:0.14.6
       env:
@@ -51,7 +49,6 @@ jobs:
   terraform-tflint:
     name: 'Terraform-tflint'
     runs-on: ubuntu-latest
-    environment: dev
     container:
       image: wata727/tflint
       env:

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -1,0 +1,67 @@
+name: 'Terraform-ci'
+
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: sh
+
+jobs:
+  # Terraform init and validate configuration
+  terraform-init:
+    name: 'Terraform-init'
+    runs-on: ubuntu-latest
+    environment: dev
+    container:
+      image: hashicorp/terraform:0.14.6
+      env:
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Terraform Init l1
+      working-directory: ./terraform/layer1-aws
+      run: terraform init -backend=false
+    - name: Terraform Init l2
+      working-directory: ./terraform/layer2-k8s
+      run: terraform init -backend=false
+    - name: Terraform Validate l1
+      working-directory: ./terraform/layer1-aws
+      run: terraform validate -no-color .
+    - name: Terraform Validate l2
+      working-directory: ./terraform/layer2-k8s
+      run: terraform validate -no-color .
+
+  # Checks that all Terraform configuration files format
+  terraform-format:
+    name: 'Terraform-format'
+    runs-on: ubuntu-latest
+    environment: dev
+    container:
+      image: hashicorp/terraform:0.14.6
+      env:
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Terraform Format
+      run: terraform fmt -recursive -write=false -check .
+
+  # Checks that all Terraform configuration files tflint
+  terraform-tflint:
+    name: 'Terraform-tflint'
+    runs-on: ubuntu-latest
+    environment: dev
+    container:
+      image: wata727/tflint
+      env:
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Terraform tflint l1
+      working-directory: ./terraform/layer1-aws
+      run: tflint --no-color
+    - name: Terraform tflint l2
+      working-directory: ./terraform/layer2-k8s
+      run: tflint --no-color

--- a/terraform/modules/aws-ec2-pritunl/efs.tf
+++ b/terraform/modules/aws-ec2-pritunl/efs.tf
@@ -7,8 +7,8 @@ resource "aws_efs_file_system" "this" {
   kms_key_id     = var.kms_key_id
 
   tags = {
-      "Name" = var.name
-    }
+    "Name" = var.name
+  }
   lifecycle {
     ignore_changes = [
       tags,
@@ -17,7 +17,7 @@ resource "aws_efs_file_system" "this" {
 }
 
 resource "aws_efs_mount_target" "this" {
-  count = length(var.public_subnets)
+  count          = length(var.public_subnets)
   file_system_id = aws_efs_file_system.this.id
   subnet_id      = var.public_subnets[count.index]
   security_groups = [


### PR DESCRIPTION
Added github actions to implement automatic verification of Terraform code, at the stage of checking PR and committing to all branches, performs steps:  
- `terraform-init` - Init and validate Terraform code (terraform init, terraform validate)
- `terraform-format` - Check Terraform code format (terraform fmt)
- `terraform-tflint` - Find possible problems with Terraform code linter (tflint)

Additionally formatted pritunl module `aws-ec2-pritunl/efs.tf` according to terraform format code to pass the `terraform-format` stage.