### PR TITLE
Set helm releases history size.

### DIFF
--- a/terraform/layer2-k8s/eks-aws-node-termination-handler.tf
+++ b/terraform/layer2-k8s/eks-aws-node-termination-handler.tf
@@ -1,10 +1,11 @@
 resource "helm_release" "aws_node_termination_handler" {
-  name       = "aws-node-termination-handler"
-  chart      = "aws-node-termination-handler"
-  version    = var.aws_node_termination_handler_version
-  repository = local.helm_repo_eks
-  namespace  = kubernetes_namespace.sys.id
-  wait       = false
+  name        = "aws-node-termination-handler"
+  chart       = "aws-node-termination-handler"
+  version     = var.aws_node_termination_handler_version
+  repository  = local.helm_repo_eks
+  namespace   = kubernetes_namespace.sys.id
+  wait        = false
+  max_history = "3"
 
   values = [
     file("${path.module}/templates/aws-node-termination-handler-values.yaml")

--- a/terraform/layer2-k8s/eks-aws-node-termination-handler.tf
+++ b/terraform/layer2-k8s/eks-aws-node-termination-handler.tf
@@ -5,7 +5,7 @@ resource "helm_release" "aws_node_termination_handler" {
   repository  = local.helm_repo_eks
   namespace   = kubernetes_namespace.sys.id
   wait        = false
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     file("${path.module}/templates/aws-node-termination-handler-values.yaml")

--- a/terraform/layer2-k8s/eks-cert-manager.tf
+++ b/terraform/layer2-k8s/eks-cert-manager.tf
@@ -15,12 +15,13 @@ data "template_file" "cert_manager" {
 }
 
 resource "helm_release" "cert_manager" {
-  name       = "cert-manager"
-  chart      = "cert-manager"
-  repository = local.helm_repo_certmanager
-  namespace  = kubernetes_namespace.certmanager.id
-  version    = var.cert_manager_version
-  wait       = true
+  name        = "cert-manager"
+  chart       = "cert-manager"
+  repository  = local.helm_repo_certmanager
+  namespace   = kubernetes_namespace.certmanager.id
+  version     = var.cert_manager_version
+  wait        = true
+  max_history = "3"
 
   values = [
     data.template_file.cert_manager.rendered,

--- a/terraform/layer2-k8s/eks-cert-manager.tf
+++ b/terraform/layer2-k8s/eks-cert-manager.tf
@@ -21,7 +21,7 @@ resource "helm_release" "cert_manager" {
   namespace   = kubernetes_namespace.certmanager.id
   version     = var.cert_manager_version
   wait        = true
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     data.template_file.cert_manager.rendered,

--- a/terraform/layer2-k8s/eks-certificate.tf
+++ b/terraform/layer2-k8s/eks-certificate.tf
@@ -8,10 +8,11 @@ data "template_file" "certificate" {
 }
 
 resource "helm_release" "certificate" {
-  name      = "certificate"
-  chart     = "../../helm-charts/certificate"
-  namespace = module.ing_namespace.name
-  wait      = false
+  name        = "certificate"
+  chart       = "../../helm-charts/certificate"
+  namespace   = module.ing_namespace.name
+  wait        = false
+  max_history = "3"
 
   values = [
     data.template_file.certificate.rendered,

--- a/terraform/layer2-k8s/eks-certificate.tf
+++ b/terraform/layer2-k8s/eks-certificate.tf
@@ -12,7 +12,7 @@ resource "helm_release" "certificate" {
   chart       = "../../helm-charts/certificate"
   namespace   = module.ing_namespace.name
   wait        = false
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     data.template_file.certificate.rendered,

--- a/terraform/layer2-k8s/eks-cluster-autoscaler.tf
+++ b/terraform/layer2-k8s/eks-cluster-autoscaler.tf
@@ -19,11 +19,12 @@ data "template_file" "cluster_autoscaler" {
 }
 
 resource "helm_release" "cluster_autoscaler" {
-  name       = "cluster-autoscaler"
-  chart      = "cluster-autoscaler"
-  repository = local.helm_repo_cluster_autoscaler
-  version    = var.cluster_autoscaler_chart_version
-  namespace  = kubernetes_namespace.sys.id
+  name        = "cluster-autoscaler"
+  chart       = "cluster-autoscaler"
+  repository  = local.helm_repo_cluster_autoscaler
+  version     = var.cluster_autoscaler_chart_version
+  namespace   = kubernetes_namespace.sys.id
+  max_history = "3"
 
   values = [
     data.template_file.cluster_autoscaler.rendered,

--- a/terraform/layer2-k8s/eks-cluster-autoscaler.tf
+++ b/terraform/layer2-k8s/eks-cluster-autoscaler.tf
@@ -24,7 +24,7 @@ resource "helm_release" "cluster_autoscaler" {
   repository  = local.helm_repo_cluster_autoscaler
   version     = var.cluster_autoscaler_chart_version
   namespace   = kubernetes_namespace.sys.id
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     data.template_file.cluster_autoscaler.rendered,

--- a/terraform/layer2-k8s/eks-cluster-issuer.tf
+++ b/terraform/layer2-k8s/eks-cluster-issuer.tf
@@ -9,10 +9,11 @@ data "template_file" "cluster_issuer" {
 }
 
 resource "helm_release" "cluster_issuer" {
-  name      = "cluster-issuer"
-  chart     = "../../helm-charts/cluster-issuer"
-  namespace = kubernetes_namespace.certmanager.id
-  wait      = false
+  name        = "cluster-issuer"
+  chart       = "../../helm-charts/cluster-issuer"
+  namespace   = kubernetes_namespace.certmanager.id
+  wait        = false
+  max_history = "3"
 
   values = [
     data.template_file.cluster_issuer.rendered,

--- a/terraform/layer2-k8s/eks-cluster-issuer.tf
+++ b/terraform/layer2-k8s/eks-cluster-issuer.tf
@@ -13,7 +13,7 @@ resource "helm_release" "cluster_issuer" {
   chart       = "../../helm-charts/cluster-issuer"
   namespace   = kubernetes_namespace.certmanager.id
   wait        = false
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     data.template_file.cluster_issuer.rendered,

--- a/terraform/layer2-k8s/eks-external-dns.tf
+++ b/terraform/layer2-k8s/eks-external-dns.tf
@@ -24,7 +24,7 @@ resource "helm_release" "external_dns" {
   repository  = local.helm_repo_bitnami
   version     = var.external_dns_version
   namespace   = kubernetes_namespace.dns.id
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     data.template_file.external_dns.rendered,

--- a/terraform/layer2-k8s/eks-external-dns.tf
+++ b/terraform/layer2-k8s/eks-external-dns.tf
@@ -19,11 +19,12 @@ data "template_file" "external_dns" {
 
 
 resource "helm_release" "external_dns" {
-  name       = "external-dns"
-  chart      = "external-dns"
-  repository = local.helm_repo_bitnami
-  version    = var.external_dns_version
-  namespace  = kubernetes_namespace.dns.id
+  name        = "external-dns"
+  chart       = "external-dns"
+  repository  = local.helm_repo_bitnami
+  version     = var.external_dns_version
+  namespace   = kubernetes_namespace.dns.id
+  max_history = "3"
 
   values = [
     data.template_file.external_dns.rendered,

--- a/terraform/layer2-k8s/eks-external-secrets.tf
+++ b/terraform/layer2-k8s/eks-external-secrets.tf
@@ -16,11 +16,12 @@ data "template_file" "external_secrets" {
 }
 
 resource "helm_release" "external_secrets" {
-  name       = "external-secrets"
-  chart      = "kubernetes-external-secrets"
-  repository = local.helm_repo_external_secrets
-  version    = var.external_secrets_version
-  namespace  = kubernetes_namespace.sys.id
+  name        = "external-secrets"
+  chart       = "kubernetes-external-secrets"
+  repository  = local.helm_repo_external_secrets
+  version     = var.external_secrets_version
+  namespace   = kubernetes_namespace.sys.id
+  max_history = "3"
 
   values = [
     data.template_file.external_secrets.rendered,
@@ -28,12 +29,13 @@ resource "helm_release" "external_secrets" {
 }
 
 resource "helm_release" "reloader" {
-  name       = "reloader"
-  chart      = "reloader"
-  repository = local.helm_repo_stakater
-  version    = var.reloader_version
-  namespace  = kubernetes_namespace.sys.id
-  wait       = false
+  name        = "reloader"
+  chart       = "reloader"
+  repository  = local.helm_repo_stakater
+  version     = var.reloader_version
+  namespace   = kubernetes_namespace.sys.id
+  wait        = false
+  max_history = "3"
 }
 
 #module "aws_iam_wp_external_secrets" {

--- a/terraform/layer2-k8s/eks-external-secrets.tf
+++ b/terraform/layer2-k8s/eks-external-secrets.tf
@@ -21,7 +21,7 @@ resource "helm_release" "external_secrets" {
   repository  = local.helm_repo_external_secrets
   version     = var.external_secrets_version
   namespace   = kubernetes_namespace.sys.id
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     data.template_file.external_secrets.rendered,
@@ -35,7 +35,7 @@ resource "helm_release" "reloader" {
   version     = var.reloader_version
   namespace   = kubernetes_namespace.sys.id
   wait        = false
-  max_history = "3"
+  max_history = var.helm_release_history_size
 }
 
 #module "aws_iam_wp_external_secrets" {

--- a/terraform/layer2-k8s/eks-kube-prometheus-stack.tf
+++ b/terraform/layer2-k8s/eks-kube-prometheus-stack.tf
@@ -35,17 +35,13 @@ module "aws_iam_grafana" {
 }
 
 resource "helm_release" "prometheus_operator" {
-  name       = "kube-prometheus-stack"
-  chart      = "kube-prometheus-stack"
-  repository = local.helm_repo_prometheus_community
-  namespace  = kubernetes_namespace.monitoring.id
-  version    = var.prometheus_operator_version
-  wait       = false
-
-  set {
-    name  = "rbac.create"
-    value = "true"
-  }
+  name        = "kube-prometheus-stack"
+  chart       = "kube-prometheus-stack"
+  repository  = local.helm_repo_prometheus_community
+  namespace   = kubernetes_namespace.monitoring.id
+  version     = var.prometheus_operator_version
+  wait        = false
+  max_history = "3"
 
   values = [
     local.kube_prometheus_stack_template

--- a/terraform/layer2-k8s/eks-kube-prometheus-stack.tf
+++ b/terraform/layer2-k8s/eks-kube-prometheus-stack.tf
@@ -41,7 +41,7 @@ resource "helm_release" "prometheus_operator" {
   namespace   = kubernetes_namespace.monitoring.id
   version     = var.prometheus_operator_version
   wait        = false
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     local.kube_prometheus_stack_template

--- a/terraform/layer2-k8s/eks-loki-stack.tf
+++ b/terraform/layer2-k8s/eks-loki-stack.tf
@@ -18,7 +18,7 @@ resource "helm_release" "loki_stack" {
   namespace   = kubernetes_namespace.monitoring.id
   version     = var.loki_stack
   wait        = false
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     local.loki_stack_template

--- a/terraform/layer2-k8s/eks-loki-stack.tf
+++ b/terraform/layer2-k8s/eks-loki-stack.tf
@@ -12,12 +12,13 @@ locals {
 }
 
 resource "helm_release" "loki_stack" {
-  name       = "loki-stack"
-  chart      = "loki-stack"
-  repository = local.helm_repo_grafana
-  namespace  = kubernetes_namespace.monitoring.id
-  version    = var.loki_stack
-  wait       = false
+  name        = "loki-stack"
+  chart       = "loki-stack"
+  repository  = local.helm_repo_grafana
+  namespace   = kubernetes_namespace.monitoring.id
+  version     = var.loki_stack
+  wait        = false
+  max_history = "3"
 
   values = [
     local.loki_stack_template

--- a/terraform/layer2-k8s/eks-network-policy.tf
+++ b/terraform/layer2-k8s/eks-network-policy.tf
@@ -3,12 +3,13 @@ data "template_file" "calico_daemonset" {
 }
 
 resource "helm_release" "calico_daemonset" {
-  name       = "aws-calico"
-  chart      = "aws-calico"
-  repository = local.helm_repo_eks
-  version    = var.calico_daemonset
-  namespace  = "kube-system"
-  wait       = false
+  name        = "aws-calico"
+  chart       = "aws-calico"
+  repository  = local.helm_repo_eks
+  version     = var.calico_daemonset
+  namespace   = "kube-system"
+  max_history = var.helm_release_history_size
+  wait        = false
 
   values = [
     data.template_file.calico_daemonset.rendered,

--- a/terraform/layer2-k8s/eks-nginx-ingress-controller.tf
+++ b/terraform/layer2-k8s/eks-nginx-ingress-controller.tf
@@ -25,7 +25,7 @@ resource "helm_release" "nginx_ingress" {
   namespace   = module.ing_namespace.name
   version     = var.nginx_ingress_controller_version
   wait        = false
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     data.template_file.nginx_ingress.rendered,

--- a/terraform/layer2-k8s/eks-nginx-ingress-controller.tf
+++ b/terraform/layer2-k8s/eks-nginx-ingress-controller.tf
@@ -19,12 +19,13 @@ data "template_file" "nginx_ingress" {
 }
 
 resource "helm_release" "nginx_ingress" {
-  name       = "ingress-nginx"
-  chart      = "ingress-nginx"
-  repository = local.helm_repo_ingress_nginx
-  namespace  = module.ing_namespace.name
-  version    = var.nginx_ingress_controller_version
-  wait       = false
+  name        = "ingress-nginx"
+  chart       = "ingress-nginx"
+  repository  = local.helm_repo_ingress_nginx
+  namespace   = module.ing_namespace.name
+  version     = var.nginx_ingress_controller_version
+  wait        = false
+  max_history = "3"
 
   values = [
     data.template_file.nginx_ingress.rendered,

--- a/terraform/layer2-k8s/examples/eks-alb-ingress-controller.tf
+++ b/terraform/layer2-k8s/examples/eks-alb-ingress-controller.tf
@@ -24,7 +24,7 @@ resource "helm_release" "alb_ingress_controller" {
   repository  = local.helm_repo_incubator
   version     = var.alb_ingress_chart_version
   namespace   = kubernetes_namespace.ing.id
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     data.template_file.alb_ingress_controller.rendered

--- a/terraform/layer2-k8s/examples/eks-alb-ingress-controller.tf
+++ b/terraform/layer2-k8s/examples/eks-alb-ingress-controller.tf
@@ -19,13 +19,14 @@ data "template_file" "alb_ingress_controller" {
 }
 
 resource "helm_release" "alb_ingress_controller" {
-  name       = "aws-alb-ingress-controller"
-  chart      = "aws-alb-ingress-controller"
-  repository = local.helm_repo_incubator
-  version    = var.alb_ingress_chart_version
-  namespace  = kubernetes_namespace.ing.id
+  name        = "aws-alb-ingress-controller"
+  chart       = "aws-alb-ingress-controller"
+  repository  = local.helm_repo_incubator
+  version     = var.alb_ingress_chart_version
+  namespace   = kubernetes_namespace.ing.id
+  max_history = "3"
 
   values = [
-    "${data.template_file.alb_ingress_controller.rendered}",
+    data.template_file.alb_ingress_controller.rendered
   ]
 }

--- a/terraform/layer2-k8s/examples/eks-apm-server.tf
+++ b/terraform/layer2-k8s/examples/eks-apm-server.tf
@@ -7,15 +7,16 @@ data "template_file" "apm-server" {
 }
 
 resource "helm_release" "apm-server" {
-  name       = "apm-server"
-  chart      = "apm-server"
-  repository = local.helm_repo_elastic
-  version    = var.elk_version
-  namespace  = kubernetes_namespace.elk.id
-  wait       = false
+  name        = "apm-server"
+  chart       = "apm-server"
+  repository  = local.helm_repo_elastic
+  version     = var.elk_version
+  namespace   = kubernetes_namespace.elk.id
+  wait        = false
+  max_history = "3"
 
   values = [
-    "${data.template_file.apm.rendered}",
+    data.template_file.apm.rendered,
   ]
 
   # This dep needs for correct apply

--- a/terraform/layer2-k8s/examples/eks-apm-server.tf
+++ b/terraform/layer2-k8s/examples/eks-apm-server.tf
@@ -13,7 +13,7 @@ resource "helm_release" "apm-server" {
   version     = var.elk_version
   namespace   = kubernetes_namespace.elk.id
   wait        = false
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     data.template_file.apm.rendered,

--- a/terraform/layer2-k8s/examples/eks-elasticsearch.tf
+++ b/terraform/layer2-k8s/examples/eks-elasticsearch.tf
@@ -14,7 +14,7 @@ resource "helm_release" "elasticsearch" {
   version     = var.elk_version
   namespace   = kubernetes_namespace.elk.id
   wait        = false
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     data.template_file.elasticsearch.rendered

--- a/terraform/layer2-k8s/examples/eks-elasticsearch.tf
+++ b/terraform/layer2-k8s/examples/eks-elasticsearch.tf
@@ -8,15 +8,16 @@ data "template_file" "elasticsearch" {
 }
 
 resource "helm_release" "elasticsearch" {
-  name       = "elasticsearch"
-  chart      = "elasticsearch"
-  repository = local.helm_repo_elastic
-  version    = var.elk_version
-  namespace  = kubernetes_namespace.elk.id
-  wait       = false
+  name        = "elasticsearch"
+  chart       = "elasticsearch"
+  repository  = local.helm_repo_elastic
+  version     = var.elk_version
+  namespace   = kubernetes_namespace.elk.id
+  wait        = false
+  max_history = "3"
 
   values = [
-    "${data.template_file.elasticsearch.rendered}",
+    data.template_file.elasticsearch.rendered
   ]
 
   # This dep needs for correct apply

--- a/terraform/layer2-k8s/examples/eks-elk.tf
+++ b/terraform/layer2-k8s/examples/eks-elk.tf
@@ -25,7 +25,7 @@ resource "helm_release" "elk" {
   chart       = "../../helm-charts/elk"
   namespace   = kubernetes_namespace.elk.id
   wait        = false
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     data.template_file.elk.rendered

--- a/terraform/layer2-k8s/examples/eks-elk.tf
+++ b/terraform/layer2-k8s/examples/eks-elk.tf
@@ -21,13 +21,14 @@ data "template_file" "elk" {
 }
 
 resource "helm_release" "elk" {
-  name      = "elk"
-  chart     = "../../helm-charts/elk"
-  namespace = kubernetes_namespace.elk.id
-  wait      = false
+  name        = "elk"
+  chart       = "../../helm-charts/elk"
+  namespace   = kubernetes_namespace.elk.id
+  wait        = false
+  max_history = "3"
 
   values = [
-    "${data.template_file.elk.rendered}",
+    data.template_file.elk.rendered
   ]
 }
 

--- a/terraform/layer2-k8s/examples/eks-filebeat.tf
+++ b/terraform/layer2-k8s/examples/eks-filebeat.tf
@@ -9,7 +9,7 @@ resource "helm_release" "filebeat" {
   version     = var.elk_version
   namespace   = kubernetes_namespace.elk.id
   wait        = false
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     data.template_file.filebeat.rendered

--- a/terraform/layer2-k8s/examples/eks-filebeat.tf
+++ b/terraform/layer2-k8s/examples/eks-filebeat.tf
@@ -3,15 +3,16 @@ data "template_file" "filebeat" {
 }
 
 resource "helm_release" "filebeat" {
-  name       = "filebeat"
-  chart      = "filebeat"
-  repository = local.helm_repo_elastic
-  version    = var.elk_version
-  namespace  = kubernetes_namespace.elk.id
-  wait       = false
+  name        = "filebeat"
+  chart       = "filebeat"
+  repository  = local.helm_repo_elastic
+  version     = var.elk_version
+  namespace   = kubernetes_namespace.elk.id
+  wait        = false
+  max_history = "3"
 
   values = [
-    "${data.template_file.filebeat.rendered}",
+    data.template_file.filebeat.rendered
   ]
 
   # This dep needs for correct apply

--- a/terraform/layer2-k8s/examples/eks-gitlab-runner.tf
+++ b/terraform/layer2-k8s/examples/eks-gitlab-runner.tf
@@ -38,7 +38,7 @@ resource "helm_release" "gitlab_runner" {
   version     = var.gitlab_runner_version
   namespace   = kubernetes_namespace.ci.id
   wait        = false
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     local.gitlab_runner_template

--- a/terraform/layer2-k8s/examples/eks-gitlab-runner.tf
+++ b/terraform/layer2-k8s/examples/eks-gitlab-runner.tf
@@ -32,12 +32,13 @@ module "eks_rbac_gitlab_runner" {
 }
 
 resource "helm_release" "gitlab_runner" {
-  name       = "gitlab-runner"
-  chart      = "gitlab-runner"
-  repository = local.helm_repo_gitlab
-  version    = var.gitlab_runner_version
-  namespace  = kubernetes_namespace.ci.id
-  wait       = false
+  name        = "gitlab-runner"
+  chart       = "gitlab-runner"
+  repository  = local.helm_repo_gitlab
+  version     = var.gitlab_runner_version
+  namespace   = kubernetes_namespace.ci.id
+  wait        = false
+  max_history = "3"
 
   values = [
     local.gitlab_runner_template

--- a/terraform/layer2-k8s/examples/eks-istio.tf
+++ b/terraform/layer2-k8s/examples/eks-istio.tf
@@ -13,8 +13,9 @@ resource "helm_release" "istio_operator_resources" {
   name  = "istio-operator-resources"
   chart = "../../helm-charts/istio/istio-operator-resources"
 
-  namespace = module.istio_system_namespace.name
-  wait      = true
+  namespace   = module.istio_system_namespace.name
+  wait        = true
+  max_history = "3"
 
   values = [
     file("${path.module}/templates/istio/istio-resources-values.yaml")
@@ -33,8 +34,9 @@ resource "helm_release" "istio_resources" {
   name  = "istio-resources"
   chart = "../../helm-charts/istio/istio-resources"
 
-  namespace = module.istio_system_namespace.name
-  wait      = false
+  namespace   = module.istio_system_namespace.name
+  wait        = false
+  max_history = "3"
 
   values = [
     file("${path.module}/templates/istio/istio-resources-values.yaml")
@@ -44,12 +46,13 @@ resource "helm_release" "istio_resources" {
 }
 
 resource "helm_release" "kiali" {
-  name       = "kiali-server"
-  chart      = "kiali-server"
-  repository = local.helm_repo_kiali
-  namespace  = module.kiali_namespace.name
-  version    = var.kiali_version
-  wait       = false
+  name        = "kiali-server"
+  chart       = "kiali-server"
+  repository  = local.helm_repo_kiali
+  namespace   = module.kiali_namespace.name
+  version     = var.kiali_version
+  wait        = false
+  max_history = "3"
 
   values = [
     file("${path.module}/templates/istio/istio-kiali-values.yaml")

--- a/terraform/layer2-k8s/examples/eks-istio.tf
+++ b/terraform/layer2-k8s/examples/eks-istio.tf
@@ -15,7 +15,7 @@ resource "helm_release" "istio_operator_resources" {
 
   namespace   = module.istio_system_namespace.name
   wait        = true
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     file("${path.module}/templates/istio/istio-resources-values.yaml")
@@ -36,7 +36,7 @@ resource "helm_release" "istio_resources" {
 
   namespace   = module.istio_system_namespace.name
   wait        = false
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     file("${path.module}/templates/istio/istio-resources-values.yaml")
@@ -52,7 +52,7 @@ resource "helm_release" "kiali" {
   namespace   = module.kiali_namespace.name
   version     = var.kiali_version
   wait        = false
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     file("${path.module}/templates/istio/istio-kiali-values.yaml")

--- a/terraform/layer2-k8s/examples/eks-kibana.tf
+++ b/terraform/layer2-k8s/examples/eks-kibana.tf
@@ -36,15 +36,16 @@ data "template_file" "kibana" {
 }
 
 resource "helm_release" "kibana" {
-  name       = "kibana"
-  chart      = "kibana"
-  repository = local.helm_repo_elastic
-  version    = var.elk_version
-  namespace  = kubernetes_namespace.elk.id
-  wait       = false
+  name        = "kibana"
+  chart       = "kibana"
+  repository  = local.helm_repo_elastic
+  version     = var.elk_version
+  namespace   = kubernetes_namespace.elk.id
+  wait        = false
+  max_history = "3"
 
   values = [
-    "${data.template_file.kibana.rendered}",
+    data.template_file.kibana.rendered
   ]
 
   # This dep needs for correct apply

--- a/terraform/layer2-k8s/examples/eks-kibana.tf
+++ b/terraform/layer2-k8s/examples/eks-kibana.tf
@@ -42,7 +42,7 @@ resource "helm_release" "kibana" {
   version     = var.elk_version
   namespace   = kubernetes_namespace.elk.id
   wait        = false
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     data.template_file.kibana.rendered

--- a/terraform/layer2-k8s/examples/eks-metricbeat.tf
+++ b/terraform/layer2-k8s/examples/eks-metricbeat.tf
@@ -3,15 +3,16 @@ data "template_file" "metricbeat" {
 }
 
 resource "helm_release" "metricbeat" {
-  name       = "metricbeat"
-  chart      = "metricbeat"
-  repository = local.helm_repo_elastic
-  version    = var.elk_version
-  namespace  = kubernetes_namespace.elk.id
-  wait       = false
+  name        = "metricbeat"
+  chart       = "metricbeat"
+  repository  = local.helm_repo_elastic
+  version     = var.elk_version
+  namespace   = kubernetes_namespace.elk.id
+  wait        = false
+  max_history = "3"
 
   values = [
-    "${data.template_file.metricbeat.rendered}",
+    data.template_file.metricbeat.rendered
   ]
 
   # This dep needs for correct apply

--- a/terraform/layer2-k8s/examples/eks-metricbeat.tf
+++ b/terraform/layer2-k8s/examples/eks-metricbeat.tf
@@ -9,7 +9,7 @@ resource "helm_release" "metricbeat" {
   version     = var.elk_version
   namespace   = kubernetes_namespace.elk.id
   wait        = false
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     data.template_file.metricbeat.rendered

--- a/terraform/layer2-k8s/examples/eks-mysql-backup-wp.tf
+++ b/terraform/layer2-k8s/examples/eks-mysql-backup-wp.tf
@@ -34,15 +34,16 @@ data "template_file" "mysql_backup_wp" {
 }
 
 resource "helm_release" "mysql_backup_wp" {
-  name       = "mysql-backup"
-  chart      = "mysql-backup"
-  repository = local.helm_repo_softonic
-  version    = "2.1.4"
-  namespace  = kubernetes_namespace.wp.id
-  wait       = false
+  name        = "mysql-backup"
+  chart       = "mysql-backup"
+  repository  = local.helm_repo_softonic
+  version     = "2.1.4"
+  namespace   = kubernetes_namespace.wp.id
+  wait        = false
+  max_history = "3"
 
   values = [
-    "${data.template_file.mysql_backup_wp.rendered}",
+    data.template_file.mysql_backup_wp.rendered
   ]
 
   # This dep needs for correct apply

--- a/terraform/layer2-k8s/examples/eks-mysql-backup-wp.tf
+++ b/terraform/layer2-k8s/examples/eks-mysql-backup-wp.tf
@@ -40,7 +40,7 @@ resource "helm_release" "mysql_backup_wp" {
   version     = "2.1.4"
   namespace   = kubernetes_namespace.wp.id
   wait        = false
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     data.template_file.mysql_backup_wp.rendered

--- a/terraform/layer2-k8s/examples/eks-oauth2-proxy.tf
+++ b/terraform/layer2-k8s/examples/eks-oauth2-proxy.tf
@@ -33,7 +33,7 @@ resource "helm_release" "oauth2_proxy" {
   version     = var.oauth2_proxy_version
   namespace   = kubernetes_namespace.elk.id
   wait        = false
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     data.template_file.oauth2_proxy.rendered

--- a/terraform/layer2-k8s/examples/eks-oauth2-proxy.tf
+++ b/terraform/layer2-k8s/examples/eks-oauth2-proxy.tf
@@ -27,15 +27,16 @@ data "template_file" "oauth2_proxy" {
 }
 
 resource "helm_release" "oauth2_proxy" {
-  name       = "oauth2-proxy"
-  chart      = "oauth2-proxy"
-  repository = local.helm_repo_stable
-  version    = var.oauth2_proxy_version
-  namespace  = kubernetes_namespace.elk.id
-  wait       = false
+  name        = "oauth2-proxy"
+  chart       = "oauth2-proxy"
+  repository  = local.helm_repo_stable
+  version     = var.oauth2_proxy_version
+  namespace   = kubernetes_namespace.elk.id
+  wait        = false
+  max_history = "3"
 
   values = [
-    "${data.template_file.oauth2_proxy.rendered}",
+    data.template_file.oauth2_proxy.rendered
   ]
 }
 

--- a/terraform/layer2-k8s/examples/eks-postgresql-backups.tf
+++ b/terraform/layer2-k8s/examples/eks-postgresql-backups.tf
@@ -10,7 +10,7 @@ resource "helm_release" "postgresql_backups" {
   chart       = "../../helm-charts/postgresql-backups"
   namespace   = kubernetes_namespace.prod.id
   wait        = false
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     local.postgresql_backups_template

--- a/terraform/layer2-k8s/examples/eks-postgresql-backups.tf
+++ b/terraform/layer2-k8s/examples/eks-postgresql-backups.tf
@@ -6,10 +6,11 @@ locals {
 }
 
 resource "helm_release" "postgresql_backups" {
-  name      = "postgresql-backups"
-  chart     = "../../helm-charts/postgresql-backups"
-  namespace = kubernetes_namespace.prod.id
-  wait      = false
+  name        = "postgresql-backups"
+  chart       = "../../helm-charts/postgresql-backups"
+  namespace   = kubernetes_namespace.prod.id
+  wait        = false
+  max_history = "3"
 
   values = [
     local.postgresql_backups_template

--- a/terraform/layer2-k8s/examples/eks-prometheus-mysql-exporter.tf
+++ b/terraform/layer2-k8s/examples/eks-prometheus-mysql-exporter.tf
@@ -3,15 +3,16 @@ data "template_file" "prometheus_mysql_exporter" {
 }
 
 resource "helm_release" "prometheus_mysql_exporter_wp" {
-  name       = "prometheus-mysql-exporter"
-  chart      = "prometheus-mysql-exporter"
-  version    = var.prometheus_mysql_exporter_version
-  repository = local.helm_repo_prometheus_community
-  namespace  = kubernetes_namespace.wp.id
-  wait       = false
+  name        = "prometheus-mysql-exporter"
+  chart       = "prometheus-mysql-exporter"
+  version     = var.prometheus_mysql_exporter_version
+  repository  = local.helm_repo_prometheus_community
+  namespace   = kubernetes_namespace.wp.id
+  wait        = false
+  max_history = "3"
 
   values = [
-    "${data.template_file.prometheus_mysql_exporter.rendered}",
+    data.template_file.prometheus_mysql_exporter.rendered
   ]
 
   # This dep needs for correct apply

--- a/terraform/layer2-k8s/examples/eks-prometheus-mysql-exporter.tf
+++ b/terraform/layer2-k8s/examples/eks-prometheus-mysql-exporter.tf
@@ -9,7 +9,7 @@ resource "helm_release" "prometheus_mysql_exporter_wp" {
   repository  = local.helm_repo_prometheus_community
   namespace   = kubernetes_namespace.wp.id
   wait        = false
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     data.template_file.prometheus_mysql_exporter.rendered

--- a/terraform/layer2-k8s/examples/eks-prometheus-postgresql-exporter.tf
+++ b/terraform/layer2-k8s/examples/eks-prometheus-postgresql-exporter.tf
@@ -27,10 +27,11 @@ locals {
 }
 
 resource "helm_release" "postgresql_exporter_user" {
-  name      = "pg-exporter-user"
-  chart     = "../../helm-charts/pg-exporter-user"
-  namespace = kubernetes_namespace.monitoring.id
-  wait      = false
+  name        = "pg-exporter-user"
+  chart       = "../../helm-charts/pg-exporter-user"
+  namespace   = kubernetes_namespace.monitoring.id
+  wait        = false
+  max_history = "3"
 
   values = [
     local.postgresql_exporter_user_template
@@ -38,12 +39,13 @@ resource "helm_release" "postgresql_exporter_user" {
 }
 
 resource "helm_release" "postgresql_exporter" {
-  name       = "prometheus-postgres-exporter"
-  chart      = "prometheus-postgres-exporter"
-  repository = local.helm_repo_prometheus_community
-  version    = "1.4.0"
-  namespace  = kubernetes_namespace.monitoring.id
-  wait       = false
+  name        = "prometheus-postgres-exporter"
+  chart       = "prometheus-postgres-exporter"
+  repository  = local.helm_repo_prometheus_community
+  version     = "1.4.0"
+  namespace   = kubernetes_namespace.monitoring.id
+  wait        = false
+  max_history = "3"
 
   values = [
     local.prometheus_postgresql_exporter_template

--- a/terraform/layer2-k8s/examples/eks-prometheus-postgresql-exporter.tf
+++ b/terraform/layer2-k8s/examples/eks-prometheus-postgresql-exporter.tf
@@ -31,7 +31,7 @@ resource "helm_release" "postgresql_exporter_user" {
   chart       = "../../helm-charts/pg-exporter-user"
   namespace   = kubernetes_namespace.monitoring.id
   wait        = false
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     local.postgresql_exporter_user_template
@@ -45,7 +45,7 @@ resource "helm_release" "postgresql_exporter" {
   version     = "1.4.0"
   namespace   = kubernetes_namespace.monitoring.id
   wait        = false
-  max_history = "3"
+  max_history = var.helm_release_history_size
 
   values = [
     local.prometheus_postgresql_exporter_template

--- a/terraform/layer2-k8s/examples/eks-teamcity.tf
+++ b/terraform/layer2-k8s/examples/eks-teamcity.tf
@@ -43,7 +43,7 @@ resource "helm_release" "teamcity" {
   namespace       = kubernetes_namespace.ci.id
   wait            = false
   cleanup_on_fail = true
-  max_history     = "3"
+  max_history     = var.helm_release_history_size
 
   values = [
     data.template_file.teamcity.rendered

--- a/terraform/layer2-k8s/examples/eks-teamcity.tf
+++ b/terraform/layer2-k8s/examples/eks-teamcity.tf
@@ -43,8 +43,10 @@ resource "helm_release" "teamcity" {
   namespace       = kubernetes_namespace.ci.id
   wait            = false
   cleanup_on_fail = true
+  max_history     = "3"
+
   values = [
-    "${data.template_file.teamcity.rendered}",
+    data.template_file.teamcity.rendered
   ]
 }
 

--- a/terraform/layer2-k8s/variables.tf
+++ b/terraform/layer2-k8s/variables.tf
@@ -146,3 +146,8 @@ variable "calico_daemonset" {
   description = "Version of calico helm chart"
   default     = "0.3.4"
 }
+
+variable "helm_release_history_size" {
+  description = "How much helm releases to store"
+  default     = 5
+}


### PR DESCRIPTION
Helm keeps releases history as k8s secrets. If we don't set max_history it will be unlimited.
There is an opened issue related to that https://github.com/helm/helm/issues/7997.
If count of secrets is huge then helm list/istall can be failed due to:
```
request.go:924] Unexpected error when reading response body: net/http: request canceled (Client.Timeout exceeded while reading body)
Error: unable to build kubernetes objects from release manifest: unexpected error when reading response body. Please retry. Original error: net/http: request canceled (Client.Timeout exceeded while reading body
```