### PR TITLE
#43 changed log-level for external-secrets and calico

### DIFF
--- a/terraform/layer2-k8s/templates/calico-values.yaml
+++ b/terraform/layer2-k8s/templates/calico-values.yaml
@@ -10,7 +10,7 @@ calico:
   tag: v3.15.1
 
   typha:
-    logseverity: Info #Debug, Info, Warning, Error, Fatal
+    logseverity: Warning #Debug, Info, Warning, Error, Fatal
     image: quay.io/calico/typha
     resources:
       requests:
@@ -24,7 +24,7 @@ calico:
       beta.kubernetes.io/os: linux
     podAnnotations: {}
   node:
-    logseverity: Info #Debug, Info, Warning, Error, Fatal
+    logseverity: Warning #Debug, Info, Warning, Error, Fatal
     image: quay.io/calico/node
     resources:
       requests:

--- a/terraform/layer2-k8s/templates/external-secrets-values.yaml
+++ b/terraform/layer2-k8s/templates/external-secrets-values.yaml
@@ -3,7 +3,8 @@ env:
   AWS_REGION: ${region}
   AWS_DEFAULT_REGION: ${region}
   POLLER_INTERVAL_MILLISECONDS: 30000
-  LOG_LEVEL: info
+  # trace, debug, info, warn, error, fatal
+  LOG_LEVEL: warn
   LOG_MESSAGE_KEY: 'msg'
   METRICS_PORT: 3001
 


### PR DESCRIPTION
* Changed log level for external-secrets from info to warning.
* Changed log level for calico from info to warn.