### PR TITLE
Add option to enable eks_cluster_encryption_config

### DIFF
--- a/terraform/layer1-aws/aws-eks.tf
+++ b/terraform/layer1-aws/aws-eks.tf
@@ -14,6 +14,13 @@ module "eks" {
 
   vpc_id = module.vpc.vpc_id
 
+  cluster_encryption_config = var.eks_cluster_encryption_config_enable ? [
+    {
+      provider_key_arn = aws_kms_key.eks[0].arn
+      resources        = ["secrets"]
+    }
+  ] : []
+
   worker_groups_launch_template = [
     {
       name                    = "spot"

--- a/terraform/layer1-aws/aws-kms.tf
+++ b/terraform/layer1-aws/aws-kms.tf
@@ -1,0 +1,4 @@
+resource "aws_kms_key" "eks" {
+  count       = var.eks_cluster_encryption_config_enable ? 1 : 0
+  description = "EKS Secret Encryption Key"
+}

--- a/terraform/layer1-aws/demo.tfvars.example
+++ b/terraform/layer1-aws/demo.tfvars.example
@@ -20,6 +20,8 @@ single_nat_gateway = true
 ##########
 eks_cluster_version = "1.19"
 
+eks_cluster_encryption_config_enable = true
+
 eks_worker_groups = {
   spot = {
     override_instance_types = ["t3.medium", "t3a.medium"]

--- a/terraform/layer1-aws/variables.tf
+++ b/terraform/layer1-aws/variables.tf
@@ -147,3 +147,9 @@ variable "ecr_repo_retention_count" {
   default     = 50
   description = "number of images to store in ECR"
 }
+
+variable "eks_cluster_encryption_config_enable" {
+  type        = bool
+  default     = false
+  description = "Enable or not encryption for k8s secrets with aws-kms"
+}


### PR DESCRIPTION
AWS promoted functionality to encrypt k8s secrets and configmaps using AWS KMS (https://aws.amazon.com/about-aws/whats-new/2020/03/amazon-eks-adds-envelope-encryption-for-secrets-with-aws-kms/). 
This PR adds the option to enable this feature. 