### PR TITLE
#108 fixed affinity for the node termination handler

### DIFF
--- a/terraform/layer2-k8s/templates/aws-node-termination-handler-values.yaml
+++ b/terraform/layer2-k8s/templates/aws-node-termination-handler-values.yaml
@@ -1,4 +1,14 @@
 enableSpotInterruptionDraining: true
 enableRebalanceMonitoring: true
-nodeSelector:
-  eks.amazonaws.com/capacityType: SPOT
+
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: eks.amazonaws.com/capacityType
+          operator: In
+          values:
+          - SPOT
+        - key: eks.amazonaws.com/nodegroup
+          operator: DoesNotExist


### PR DESCRIPTION
# Changes
* fixed node affinity for the node termination handler, preventing it to run on managed node groups