### PR TITLE
use EKS add-ons to install/upgrade internal components, such as vpc-cni, kube-proxy, coredns

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ You can find more about this project in Anton Babenko stream:
   - [Table of contents](#table-of-contents)
   - [Architecture diagram](#architecture-diagram)
   - [Current infrastructure cost](#current-infrastructure-cost)
+  - [EKS Upgrading](#eks-upgrading)
   - [Namespace structure in the K8S cluster](#namespace-structure-in-the-k8s-cluster)
   - [Useful tools](#useful-tools)
   - [Useful VSCode extensions](#useful-vscode-extensions)
@@ -136,6 +137,19 @@ This diagram describes the default infrastructure:
 
 > The cost is indicated without counting the amount of traffic for Nat Gateway Load Balancer and S3
 
+## EKS Upgrading
+To upgrade k8s cluster to a new version, please use [official guide](https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html) and check changelog/breaking changes. 
+Starting from v1.18 EKS supports K8S add-ons. We use them to update things like vpc-cni, kube-proxy, coredns. To get the latest add-ons versions, run:
+```bash
+aws eks describe-addon-versions --kubernetes-version 1.21 --query 'addons[].[addonName, addonVersions[0].addonVersion]'
+```
+where 1.21 - is a k8s version on which we are updating. 
+DO NOT FORGET!!! to update cluster-autoscaler too. It's version must be the same as the cluster version.  
+Also ***IT'S VERY RECOMMENDED*** to check that deployed objects have actual apiVersions that won't be deleted after upgrading. There is a tool [*pluto*](https://github.com/FairwindsOps/pluto) that can help to do it.  
+```bash
+Switch to the correct cluster
+Run `pluto detect-helm -o markdown --target-versions k8s=v1.22.0`, where `k8s=v1.22.0` is a k8s version we want to update to. 
+``` 
 ## Namespace structure in the K8S cluster
 
 ![aws-base-namespaces](docs/aws-base-diagrams-Namespaces-v3.svg)

--- a/terraform/layer1-aws/aws-eks.tf
+++ b/terraform/layer1-aws/aws-eks.tf
@@ -179,3 +179,41 @@ EOT
     }
   }
 }
+
+resource "aws_eks_addon" "vpc_cni" {
+  count = var.addon_create_vpc_cni ? 1 : 0
+
+  cluster_name      = module.eks.cluster_id
+  addon_name        = "vpc-cni"
+  resolve_conflicts = "OVERWRITE"
+  addon_version     = var.addon_vpc_cni_version
+
+  tags = {
+    Environment = local.env
+  }
+}
+
+resource "aws_eks_addon" "kube_proxy" {
+  count = var.addon_create_kube_proxy ? 1 : 0
+
+  cluster_name      = module.eks.cluster_id
+  addon_name        = "kube-proxy"
+  resolve_conflicts = "OVERWRITE"
+  addon_version     = var.addon_kube_proxy_version
+
+  tags = {
+    Environment = local.env
+  }
+}
+
+resource "aws_eks_addon" "coredns" {
+  count = var.addon_create_coredns ? 1 : 0
+
+  cluster_name      = module.eks.cluster_id
+  addon_name        = "coredns"
+  resolve_conflicts = "OVERWRITE"
+  addon_version     = var.addon_coredns_version
+  tags = {
+    Environment = local.env
+  }
+}

--- a/terraform/layer1-aws/variables.tf
+++ b/terraform/layer1-aws/variables.tf
@@ -96,6 +96,31 @@ variable "eks_cluster_version" {
   description = "Version of the EKS K8S cluster"
 }
 
+variable "addon_create_vpc_cni" {
+  default     = true
+  description = "Enable vpc-cni add-on or not"
+}
+variable "addon_vpc_cni_version" {
+  default     = "v1.9.1-eksbuild.1"
+  description = "The version of vpc-cni add-on"
+}
+variable "addon_create_kube_proxy" {
+  default     = true
+  description = "Enable kube-proxy add-on or not"
+}
+variable "addon_kube_proxy_version" {
+  default     = "v1.20.4-eksbuild.2"
+  description = "The version of kube-proxy add-on"
+}
+variable "addon_create_coredns" {
+  default     = true
+  description = "Enable coredns add-on or not"
+}
+variable "addon_coredns_version" {
+  default     = "v1.8.3-eksbuild.1"
+  description = "The version of coredns add-on"
+}
+
 variable "eks_workers_additional_policies" {
   type = list(any)
   default = [


### PR DESCRIPTION
Starting from v1.18 EKS supports K8S add-ons for vpc-cni, kube-proxy, coredns. They allow us not to patch deployments/daemonsets manually. We just need to change an add-on version to the correct one. 