### PR TITLE
add depends_on for eks module

### DIFF
--- a/terraform/layer1-aws/aws-eks.tf
+++ b/terraform/layer1-aws/aws-eks.tf
@@ -178,6 +178,7 @@ EOT
       })
     }
   }
+  depends_on = [module.vpc]
 }
 
 resource "aws_eks_addon" "vpc_cni" {


### PR DESCRIPTION
this fix is needed to preinstall module.vpc, when install only module.eks