### PR TITLE
improvement: Use priority expander for cluster autoscaler configuration to prioritize spot node_pool

### DIFF
--- a/terraform/layer2-k8s/templates/cluster-autoscaler-values.yaml
+++ b/terraform/layer2-k8s/templates/cluster-autoscaler-values.yaml
@@ -12,6 +12,15 @@ rbac:
 autoDiscovery:
   clusterName: ${cluster_name}
 
+extraArgs:
+  expander: priority
+
+expanderPriorities: |
+  10:
+    - eks-${cluster_name}-ondemand.*
+  50:
+    - eks-${cluster_name}-spot.*
+
 serviceMonitor:
   enabled: true
   interval: 10s


### PR DESCRIPTION
# PR o'clock

## Description

Use priority expander (https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-are-expanders) instead of using random expander to decide what node_pool to scale.
### Checklist

- [X] Update the README.md with details of changes to the interface, this includes new environment variables, exposed ports, useful file locations, and container parameters.
