### PR TITLE
fix: disable aws_loadbalancer_controller by default

### DIFF
--- a/terraform/layer2-k8s/variables.tf
+++ b/terraform/layer2-k8s/variables.tf
@@ -63,7 +63,7 @@ variable "nginx_ingress_ssl_terminator" {
 variable "aws_loadbalancer_controller_enable" {
   description = "Disable or Enable aws-loadbalancer-controller"
   type        = bool
-  default     = true
+  default     = false
 }
 
 # Cluster autoscaler


### PR DESCRIPTION
# PR o'clock

## Description

We deploy `ingress-nginx` as a default ingress controller.
AWS Loadbalancer Controller has to be deployed if you are planning to use fargate workload. So, it isn't necessary to initially deploy it.


### Checklist

- [X] Update the README.md with details of changes to the interface, this includes new environment variables, exposed ports, useful file locations, and container parameters.
