### PR TITLE
fix: removed this prefix from r53 and acm modules outputs #223

### DIFF
--- a/terraform/layer1-aws/locals.tf
+++ b/terraform/layer1-aws/locals.tf
@@ -13,7 +13,7 @@ locals {
     Environment = local.env
   }
 
-  ssl_certificate_arn = var.create_acm_certificate ? module.acm.this_acm_certificate_arn : data.aws_acm_certificate.main[0].arn
+  ssl_certificate_arn = var.create_acm_certificate ? module.acm.acm_certificate_arn : data.aws_acm_certificate.main[0].arn
 
-  zone_id = var.create_r53_zone ? keys(module.r53_zone.this_route53_zone_zone_id)[0] : (var.zone_id != null ? var.zone_id : data.aws_route53_zone.main[0].zone_id)
+  zone_id = var.create_r53_zone ? keys(module.r53_zone.route53_zone_zone_id)[0] : (var.zone_id != null ? var.zone_id : data.aws_route53_zone.main[0].zone_id)
 }


### PR DESCRIPTION
# PR Description

Fixed acm and route53 modules outputs. Removed `this_` prefix. Which was overlooked

Fixes #223 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
