### PR TITLE
bug: allow external secrets to get secrets from AWS Secrets Manager

### DIFF
--- a/terraform/layer2-k8s/eks-external-secrets.tf
+++ b/terraform/layer2-k8s/eks-external-secrets.tf
@@ -90,7 +90,13 @@ module "aws_iam_external_secrets" {
     "Statement" : [
       {
         "Effect" : "Allow",
-        "Action" : "ssm:GetParameter",
+        "Action" : [
+          "ssm:GetParameter",
+          "secretsmanager:GetResourcePolicy",
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:ListSecretVersionIds"
+        ],
         "Resource" : "*"
       }
     ]


### PR DESCRIPTION
# PR Description

These changes allow external-secrets pod to get secrets from AWS Secrets Manager

Fixes #231 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
