### PR TITLE
bug: add server_side_apply option to kube-prometheus-stack-crd resources

### DIFF
--- a/terraform/layer2-k8s/eks-kube-prometheus-stack.tf
+++ b/terraform/layer2-k8s/eks-kube-prometheus-stack.tf
@@ -23,6 +23,24 @@ locals {
   kube_prometheus_stack_prometheus_domain_name               = "prometheus-${local.domain_suffix}"
   kube_prometheus_stack_values                               = <<VALUES
 # Prometheus Server parameters
+##############################
+### EKS specific configuration
+##############################
+kubeControllerManager:
+  enabled: false
+## Component scraping kube scheduler
+##
+kubeScheduler:
+  enabled: false
+## Component scraping kube proxy
+##
+kubeProxy:
+  enabled: false
+############
+defaultRules:
+  disabled:
+    KubeProxyDown: true
+
 prometheus:
   ingress:
     enabled: true

--- a/terraform/layer2-k8s/eks-prometheus-operator-crds.tf
+++ b/terraform/layer2-k8s/eks-prometheus-operator-crds.tf
@@ -16,6 +16,7 @@ data "http" "kube_prometheus_stack_operator_crds" {
 }
 
 resource "kubectl_manifest" "kube_prometheus_stack_operator_crds" {
-  for_each  = (local.victoria_metrics_k8s_stack.enabled || local.kube_prometheus_stack.enabled) ? { for k, v in data.http.kube_prometheus_stack_operator_crds : yamldecode(v.body).metadata.name => v.body } : {}
-  yaml_body = each.value
+  for_each          = (local.victoria_metrics_k8s_stack.enabled || local.kube_prometheus_stack.enabled) ? { for k, v in data.http.kube_prometheus_stack_operator_crds : yamldecode(v.body).metadata.name => v.body } : {}
+  yaml_body         = each.value
+  server_side_apply = true
 }

--- a/terraform/layer2-k8s/helm-releases.yaml
+++ b/terraform/layer2-k8s/helm-releases.yaml
@@ -105,7 +105,7 @@ releases:
     enabled: false
     chart: kube-prometheus-stack
     repository: https://prometheus-community.github.io/helm-charts
-    chart_version: 19.3.0 #https://github.com/prometheus-community/helm-charts/issues/1500
+    chart_version: 30.1.0
     namespace: monitoring
   - id: loki-stack
     enabled: true


### PR DESCRIPTION
# PR Description

* Added server_side_apply option for `resource "kubectl_manifest" "kube_prometheus_stack_operator_crds"`
* Updated kube-prometheus-stack to version 30.1.0
* Added EKS related configuration for Prometheus
* Disabled kubeProxy alerts
 
Fixes #247 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
