### PR TITLE
bug: fix aws-loadbalancer-controller helm chart variables

### DIFF
--- a/terraform/layer2-k8s/eks-aws-loadbalancer-controller.tf
+++ b/terraform/layer2-k8s/eks-aws-loadbalancer-controller.tf
@@ -10,7 +10,7 @@ locals {
   aws_load_balancer_controller_values = <<VALUES
 clusterName: ${local.eks_cluster_id}
 region: ${local.region}
-vpcId: ${local.eks_cluster_id}
+vpcId: ${local.vpc_id}
 
 serviceAccount:
   create: true


### PR DESCRIPTION
# PR Description

We set eks_cluster_id instead of vpc_id for `vpcId` variable. This PR fixes it. 

Fixes #243 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation