### PR TITLE
enh: change cluster-autoscaler configuration to improve cluster utilization

### DIFF
--- a/terraform/layer2-k8s/eks-cluster-autoscaler.tf
+++ b/terraform/layer2-k8s/eks-cluster-autoscaler.tf
@@ -19,6 +19,8 @@ rbac:
 autoDiscovery:
   clusterName: ${local.eks_cluster_id}
 extraArgs:
+  skip-nodes-with-local-storage: false
+  scale-down-utilization-threshold: 0.7
   expander: priority
 expanderPriorities: |
   10:


### PR DESCRIPTION
# PR Description

These changes improve cluster utilization, they allow CA (cluster-autoscaler) to scale-down nodes with utilization less than 70% (default value is 50%).

Fixes #254 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
