### PR TITLE
fix: delete unnecessary istio-sidecar configuration

### DIFF
--- a/terraform/layer2-k8s/eks-istio.tf
+++ b/terraform/layer2-k8s/eks-istio.tf
@@ -26,9 +26,6 @@ pilot:
       memory: "2Gi"
   nodeSelector:
     eks.amazonaws.com/capacityType: ON_DEMAND
-sidecarInjectorWebhook:
-  injectedAnnotations:
-    cluster-autoscaler.kubernetes.io/safe-to-evict: true # https://github.com/kubeflow/pipelines/issues/4530
 global:
   imagePullPolicy: IfNotPresent
   proxy:


### PR DESCRIPTION
# PR Description

Fixed cases when Cluster Autoscaler terminates pods aren't managed by any of the k8s controllers to downscale ASG. 

Fixes #256

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
