### PR TITLE
bug: 262 added crd thanosrulers for prometheus stack operator

### DIFF
--- a/terraform/layer2-k8s/eks-prometheus-operator-crds.tf
+++ b/terraform/layer2-k8s/eks-prometheus-operator-crds.tf
@@ -6,7 +6,8 @@ locals {
     "https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-${local.kube_prometheus_stack.chart_version}/charts/kube-prometheus-stack/crds/crd-probes.yaml",
     "https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-${local.kube_prometheus_stack.chart_version}/charts/kube-prometheus-stack/crds/crd-prometheuses.yaml",
     "https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-${local.kube_prometheus_stack.chart_version}/charts/kube-prometheus-stack/crds/crd-prometheusrules.yaml",
-    "https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-${local.kube_prometheus_stack.chart_version}/charts/kube-prometheus-stack/crds/crd-servicemonitors.yaml"
+    "https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-${local.kube_prometheus_stack.chart_version}/charts/kube-prometheus-stack/crds/crd-servicemonitors.yaml",
+    "https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-${local.kube_prometheus_stack.chart_version}/charts/kube-prometheus-stack/crds/crd-thanosrulers.yaml"
   ]
 }
 


### PR DESCRIPTION

# PR Description
Fixed problem prometheus operator is restarted continuously

Fixes [#262](https://github.com/maddevsio/aws-eks-base/issues/262#issue-1195500867) 

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
