### PR TITLE
refactor: switch from kubernetes-external-secrets to External Secrets Operator

### DIFF
--- a/terraform/layer2-k8s/README.md
+++ b/terraform/layer2-k8s/README.md
@@ -31,7 +31,6 @@
 | <a name="module_aws_iam_cert_manager"></a> [aws\_iam\_cert\_manager](#module\_aws\_iam\_cert\_manager) | ../modules/aws-iam-eks-trusted | n/a |
 | <a name="module_aws_iam_elastic_stack"></a> [aws\_iam\_elastic\_stack](#module\_aws\_iam\_elastic\_stack) | ../modules/aws-iam-user-with-policy | n/a |
 | <a name="module_aws_iam_external_dns"></a> [aws\_iam\_external\_dns](#module\_aws\_iam\_external\_dns) | ../modules/aws-iam-eks-trusted | n/a |
-| <a name="module_aws_iam_external_secrets"></a> [aws\_iam\_external\_secrets](#module\_aws\_iam\_external\_secrets) | ../modules/aws-iam-eks-trusted | n/a |
 | <a name="module_aws_iam_gitlab_runner"></a> [aws\_iam\_gitlab\_runner](#module\_aws\_iam\_gitlab\_runner) | ../modules/aws-iam-eks-trusted | n/a |
 | <a name="module_aws_iam_kube_prometheus_stack_grafana"></a> [aws\_iam\_kube\_prometheus\_stack\_grafana](#module\_aws\_iam\_kube\_prometheus\_stack\_grafana) | ../modules/aws-iam-eks-trusted | n/a |
 | <a name="module_aws_iam_victoria_metrics_k8s_stack_grafana"></a> [aws\_iam\_victoria\_metrics\_k8s\_stack\_grafana](#module\_aws\_iam\_victoria\_metrics\_k8s\_stack\_grafana) | ../modules/aws-iam-eks-trusted | n/a |

--- a/terraform/layer2-k8s/helm-releases.yaml
+++ b/terraform/layer2-k8s/helm-releases.yaml
@@ -55,9 +55,9 @@ releases:
     namespace: external-dns
   - id: external-secrets
     enabled: true
-    chart: kubernetes-external-secrets
-    repository: https://external-secrets.github.io/kubernetes-external-secrets
-    chart_version: 8.5.5
+    chart: external-secrets
+    repository: https://charts.external-secrets.io
+    chart_version: 0.5.1
     namespace: external-secrets
   - id: gitlab-runner
     enabled: false


### PR DESCRIPTION
# PR Description

* changed kubernetes-external-secrets to External Secrets Operator

How to use operator (for example with SecretsManager) can be found [here](https://external-secrets.io/v0.5.1/provider-aws-secrets-manager/).

Disabled global CRDs. So, we need to create SecretStore and ExternalSecret objects in necessary namespaces or enable them if it's needed. 

Fixes #275

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
