### PR TITLE
enh: use k8s serviceaccount + irsa for vpc-cni add-on

### DIFF
--- a/terraform/layer1-aws/README.md
+++ b/terraform/layer1-aws/README.md
@@ -24,6 +24,7 @@
 | <a name="module_pritunl"></a> [pritunl](#module\_pritunl) | ../modules/aws-ec2-pritunl | n/a |
 | <a name="module_r53_zone"></a> [r53\_zone](#module\_r53\_zone) | terraform-aws-modules/route53/aws//modules/zones | 2.5.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 3.12.0 |
+| <a name="module_vpc_cni_irsa"></a> [vpc\_cni\_irsa](#module\_vpc\_cni\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | 4.14.0 |
 | <a name="module_vpc_gateway_endpoints"></a> [vpc\_gateway\_endpoints](#module\_vpc\_gateway\_endpoints) | terraform-aws-modules/vpc/aws//modules/vpc-endpoints | 3.12.0 |
 
 ## Resources

--- a/terraform/layer1-aws/aws-eks.tf
+++ b/terraform/layer1-aws/aws-eks.tf
@@ -3,6 +3,8 @@ locals {
     "k8s.io/cluster-autoscaler/enabled"       = "true"
     "k8s.io/cluster-autoscaler/${local.name}" = "owned"
   }
+  eks_addon_vpc_cni = merge(var.eks_addons.vpc-cni, { service_account_role_arn = module.vpc_cni_irsa.iam_role_arn })
+  eks_addons        = merge(var.eks_addons, { vpc-cni = local.eks_addon_vpc_cni })
 }
 
 data "aws_ami" "eks_default_bottlerocket" {
@@ -35,7 +37,7 @@ module "eks" {
 
   vpc_id = module.vpc.vpc_id
 
-  cluster_addons = var.eks_addons
+  cluster_addons = local.eks_addons
 
   cluster_encryption_config = var.eks_cluster_encryption_config_enable ? [
     {
@@ -109,6 +111,7 @@ module "eks" {
       http_put_response_hop_limit = 1
       instance_metadata_tags      = "disabled"
     }
+    iam_role_attach_cni_policy = false
   }
 
   self_managed_node_groups = {

--- a/terraform/layer1-aws/aws-iam.tf
+++ b/terraform/layer1-aws/aws-iam.tf
@@ -2,7 +2,7 @@ module "vpc_cni_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "4.14.0"
 
-  role_name             = "${local.name}-vpc_cni"
+  role_name             = "${local.name}-vpc-cni"
   attach_vpc_cni_policy = true
   vpc_cni_enable_ipv4   = true
 

--- a/terraform/layer1-aws/aws-iam.tf
+++ b/terraform/layer1-aws/aws-iam.tf
@@ -1,0 +1,17 @@
+module "vpc_cni_irsa" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "4.14.0"
+
+  role_name             = "${local.name}-vpc_cni"
+  attach_vpc_cni_policy = true
+  vpc_cni_enable_ipv4   = true
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:aws-node"]
+    }
+  }
+
+  tags = local.tags
+}


### PR DESCRIPTION
# PR Description

Migrated from a policy attached on instances to IRSA for vpc-cni add-on

Some notes about new locals (how they look after merging):

```
> local.eks_addon_vpc_cni
{
  "addon_version" = "v1.11.0-eksbuild.1"
  "resolve_conflicts" = "OVERWRITE"
  "service_account_role_arn" = "arn"
}

> local.eks_addons
{
  "coredns" = {
    "addon_version" = "v1.8.7-eksbuild.1"
    "resolve_conflicts" = "OVERWRITE"
  }
  "kube-proxy" = {
    "addon_version" = "v1.22.6-eksbuild.1"
    "resolve_conflicts" = "OVERWRITE"
  }
  "vpc-cni" = {
    "addon_version" = "v1.11.0-eksbuild.1"
    "resolve_conflicts" = "OVERWRITE"
    "service_account_role_arn" = "arn"
  }
}
```

Fixes #279 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
