### PR TITLE
feat: CIS benchmark alerts using Eventbridge

### DIFF
--- a/terraform/layer1-aws/README.md
+++ b/terraform/layer1-aws/README.md
@@ -32,8 +32,14 @@
 
 | Name | Type |
 |------|------|
+| [aws_cloudtrail.main](https://registry.terraform.io/providers/aws/4.10.0/docs/resources/cloudtrail) | resource |
 | [aws_ebs_encryption_by_default.this](https://registry.terraform.io/providers/aws/4.10.0/docs/resources/ebs_encryption_by_default) | resource |
 | [aws_kms_key.eks](https://registry.terraform.io/providers/aws/4.10.0/docs/resources/kms_key) | resource |
+| [aws_s3_bucket.cloudtrail](https://registry.terraform.io/providers/aws/4.10.0/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_acl.cloudtrail](https://registry.terraform.io/providers/aws/4.10.0/docs/resources/s3_bucket_acl) | resource |
+| [aws_s3_bucket_lifecycle_configuration.cloudtrail](https://registry.terraform.io/providers/aws/4.10.0/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_policy.cloudtrail](https://registry.terraform.io/providers/aws/4.10.0/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_public_access_block.cloudtrail](https://registry.terraform.io/providers/aws/4.10.0/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_sns_topic.security_alerts](https://registry.terraform.io/providers/aws/4.10.0/docs/resources/sns_topic) | resource |
 | [aws_sns_topic_policy.security_alerts](https://registry.terraform.io/providers/aws/4.10.0/docs/resources/sns_topic_policy) | resource |
 | [aws_sns_topic_subscription.security_alerts](https://registry.terraform.io/providers/aws/4.10.0/docs/resources/sns_topic_subscription) | resource |
@@ -56,6 +62,7 @@
 | <a name="input_aws_cis_benchmark_alerts"></a> [aws\_cis\_benchmark\_alerts](#input\_aws\_cis\_benchmark\_alerts) | AWS CIS Benchmark alerts configuration | `any` | <pre>{<br>  "email": "demo@example.com",<br>  "enabled": "false",<br>  "rules": {<br>    "aws_config_changes_enabled": true,<br>    "cloudtrail_configuration_changes_enabled": true,<br>    "console_login_failed_enabled": true,<br>    "consolelogin_without_mfa_enabled": true,<br>    "iam_policy_changes_enabled": true,<br>    "kms_cmk_delete_or_disable_enabled": true,<br>    "nacl_changes_enabled": true,<br>    "network_gateway_changes_enabled": true,<br>    "organization_changes_enabled": true,<br>    "parameter_store_actions_enabled": true,<br>    "route_table_changes_enabled": true,<br>    "s3_bucket_policy_changes_enabled": true,<br>    "secrets_manager_actions_enabled": true,<br>    "security_group_changes_enabled": true,<br>    "unauthorized_api_calls_enabled": true,<br>    "usage_of_root_account_enabled": true,<br>    "vpc_changes_enabled": true<br>  }<br>}</pre> | no |
 | <a name="input_az_count"></a> [az\_count](#input\_az\_count) | Count of avaiablity zones, min 2 | `number` | `3` | no |
 | <a name="input_cidr"></a> [cidr](#input\_cidr) | Default CIDR block for VPC | `string` | `"10.0.0.0/16"` | no |
+| <a name="input_cloudtrail_logs_s3_expiration_days"></a> [cloudtrail\_logs\_s3\_expiration\_days](#input\_cloudtrail\_logs\_s3\_expiration\_days) | How many days keep cloudtrail logs on S3 | `string` | `180` | no |
 | <a name="input_create_acm_certificate"></a> [create\_acm\_certificate](#input\_create\_acm\_certificate) | Whether to create acm certificate or use existing | `bool` | `false` | no |
 | <a name="input_create_r53_zone"></a> [create\_r53\_zone](#input\_create\_r53\_zone) | Create R53 zone for main public domain | `bool` | `false` | no |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Main public domain name | `any` | n/a | yes |

--- a/terraform/layer1-aws/README.md
+++ b/terraform/layer1-aws/README.md
@@ -21,6 +21,7 @@
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | 3.3.0 |
 | <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 18.9.0 |
+| <a name="module_eventbridge"></a> [eventbridge](#module\_eventbridge) | terraform-aws-modules/eventbridge/aws | 1.14.0 |
 | <a name="module_pritunl"></a> [pritunl](#module\_pritunl) | ../modules/aws-ec2-pritunl | n/a |
 | <a name="module_r53_zone"></a> [r53\_zone](#module\_r53\_zone) | terraform-aws-modules/route53/aws//modules/zones | 2.5.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 3.12.0 |
@@ -33,6 +34,9 @@
 |------|------|
 | [aws_ebs_encryption_by_default.this](https://registry.terraform.io/providers/aws/4.10.0/docs/resources/ebs_encryption_by_default) | resource |
 | [aws_kms_key.eks](https://registry.terraform.io/providers/aws/4.10.0/docs/resources/kms_key) | resource |
+| [aws_sns_topic.security_alerts](https://registry.terraform.io/providers/aws/4.10.0/docs/resources/sns_topic) | resource |
+| [aws_sns_topic_policy.security_alerts](https://registry.terraform.io/providers/aws/4.10.0/docs/resources/sns_topic_policy) | resource |
+| [aws_sns_topic_subscription.security_alerts](https://registry.terraform.io/providers/aws/4.10.0/docs/resources/sns_topic_subscription) | resource |
 | [kubectl_manifest.aws_auth_configmap](https://registry.terraform.io/providers/gavinbunney/kubectl/1.14.0/docs/resources/manifest) | resource |
 | [aws_acm_certificate.main](https://registry.terraform.io/providers/aws/4.10.0/docs/data-sources/acm_certificate) | data source |
 | [aws_ami.eks_default_bottlerocket](https://registry.terraform.io/providers/aws/4.10.0/docs/data-sources/ami) | data source |
@@ -49,6 +53,7 @@
 |------|-------------|------|---------|:--------:|
 | <a name="input_allowed_account_ids"></a> [allowed\_account\_ids](#input\_allowed\_account\_ids) | List of allowed AWS account IDs | `list` | `[]` | no |
 | <a name="input_allowed_ips"></a> [allowed\_ips](#input\_allowed\_ips) | IP addresses allowed to connect to private resources | `list(any)` | `[]` | no |
+| <a name="input_aws_cis_benchmark_alerts"></a> [aws\_cis\_benchmark\_alerts](#input\_aws\_cis\_benchmark\_alerts) | AWS CIS Benchmark alerts configuration | `any` | <pre>{<br>  "email": "demo@example.com",<br>  "enabled": "false",<br>  "rules": {<br>    "aws_config_changes_enabled": true,<br>    "cloudtrail_configuration_changes_enabled": true,<br>    "console_login_failed_enabled": true,<br>    "consolelogin_without_mfa_enabled": true,<br>    "iam_policy_changes_enabled": true,<br>    "kms_cmk_delete_or_disable_enabled": true,<br>    "nacl_changes_enabled": true,<br>    "network_gateway_changes_enabled": true,<br>    "organization_changes_enabled": true,<br>    "parameter_store_actions_enabled": true,<br>    "route_table_changes_enabled": true,<br>    "s3_bucket_policy_changes_enabled": true,<br>    "secrets_manager_actions_enabled": true,<br>    "security_group_changes_enabled": true,<br>    "unauthorized_api_calls_enabled": true,<br>    "usage_of_root_account_enabled": true,<br>    "vpc_changes_enabled": true<br>  }<br>}</pre> | no |
 | <a name="input_az_count"></a> [az\_count](#input\_az\_count) | Count of avaiablity zones, min 2 | `number` | `3` | no |
 | <a name="input_cidr"></a> [cidr](#input\_cidr) | Default CIDR block for VPC | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_create_acm_certificate"></a> [create\_acm\_certificate](#input\_create\_acm\_certificate) | Whether to create acm certificate or use existing | `bool` | `false` | no |

--- a/terraform/layer1-aws/aws-cloudtrail.tf
+++ b/terraform/layer1-aws/aws-cloudtrail.tf
@@ -1,0 +1,10 @@
+resource "aws_cloudtrail" "main" {
+  name                          = local.name
+  s3_bucket_name                = aws_s3_bucket.cloudtrail.id
+  include_global_service_events = true
+  enable_log_file_validation    = true
+  enable_logging                = true
+  is_multi_region_trail         = true
+
+  tags = local.tags
+}

--- a/terraform/layer1-aws/aws-eventbridge.tf
+++ b/terraform/layer1-aws/aws-eventbridge.tf
@@ -452,5 +452,7 @@ module "eventbridge" {
       }
     ]
   }
+
+  tags = local.tags
 }
 

--- a/terraform/layer1-aws/aws-eventbridge.tf
+++ b/terraform/layer1-aws/aws-eventbridge.tf
@@ -1,0 +1,456 @@
+module "eventbridge" {
+  count   = var.aws_cis_benchmark_alerts.enabled ? 1 : 0
+  source  = "terraform-aws-modules/eventbridge/aws"
+  version = "1.14.0"
+
+  create_bus = false
+
+  rules = {
+    secrets_manager_actions = {
+      enabled     = var.aws_cis_benchmark_alerts.rules.secrets_manager_actions_enabled
+      description = "Capture all Secret Manager events"
+      event_pattern = jsonencode(
+        {
+          "source" : ["aws.secretsmanager"],
+          "detail" : {
+            "eventSource" : ["secretsmanager.amazonaws.com"],
+            "eventName" : ["CreateSecret", "UpdateSecret", "DeleteSecret", "PutSecretValue"]
+          }
+        }
+      )
+    },
+    parameter_store_actions = {
+      enabled     = var.aws_cis_benchmark_alerts.rules.parameter_store_actions_enabled
+      description = "Capture all Parameter Store events"
+      event_pattern = jsonencode(
+        {
+          "source" : ["aws.ssm"],
+          "detail-type" : ["Parameter Store Change"],
+          "detail" : {
+            "operation" : ["Create", "Update", "Delete", "LabelParameterVersion"]
+          }
+        }
+      )
+    },
+    console_login_failed = {
+      enabled     = var.aws_cis_benchmark_alerts.rules.console_login_failed_enabled
+      description = "Alert on ConsoleLogin failed authentication"
+      event_pattern = jsonencode(
+        {
+          "detail" : {
+            "eventName" : ["ConsoleLogin"],
+            "errorMessage" : ["Failed authentication"]
+          }
+        }
+      )
+    },
+    kms_cmk_delete_or_disable = {
+      enabled     = var.aws_cis_benchmark_alerts.rules.kms_cmk_delete_or_disable_enabled
+      description = "Alert on KMS disable or delete CMK"
+      event_pattern = jsonencode(
+        {
+          "source" : ["aws.kms"],
+          "detail-type" : ["AWS API Call via CloudTrail"],
+          "detail" : {
+            "eventSource" : ["kms.amazonaws.com"],
+            "eventName" : [
+              "DisableKey",
+              "ScheduleKeyDeletion"
+            ]
+          }
+        }
+      )
+    },
+    consolelogin_without_mfa = {
+      enabled     = var.aws_cis_benchmark_alerts.rules.console_login_failed_enabled
+      description = "Alert on ConsoleLogin without MFA"
+      event_pattern = jsonencode(
+        {
+          "detail-type" : ["AWS Console Sign In via CloudTrail"],
+          "detail" : {
+            "eventName" : ["ConsoleLogin"],
+            "userIdentity" : {
+              "type" : ["IAMUser"]
+            },
+            "additionalEventData" : {
+              "MFAUsed" : [{ "anything-but" : "Yes" }]
+            },
+            "responseElements" : {
+              "ConsoleLogin" : ["Success"]
+            }
+          }
+        }
+      )
+    },
+    unauthorized_api_calls = {
+      enabled     = var.aws_cis_benchmark_alerts.rules.unauthorized_api_calls_enabled
+      description = "Alert on Unauthorized-API-Calls"
+      event_pattern = jsonencode(
+        {
+          "detail-type" : ["AWS API Call via CloudTrail"],
+          "errorCode" : ["AccessDenied", "*UnauthorizedOperation"]
+        }
+      )
+    },
+    usage_of_root_account = {
+      enabled     = var.aws_cis_benchmark_alerts.rules.usage_of_root_account_enabled
+      description = "Alert on usage of Root account"
+      event_pattern = jsonencode(
+        {
+          "detail-type" : ["AWS Console Sign In via CloudTrail"],
+          "detail" : {
+            "userIdentity" : {
+              "type" : ["Root"],
+              "invokedBy" : [{ "exists" : false }]
+            },
+            "eventType" : [{ "anything-but" : "AwsServiceEvent" }]
+          }
+        }
+      )
+    },
+    iam_policy_changes = {
+      enabled     = var.aws_cis_benchmark_alerts.rules.iam_policy_changes_enabled
+      description = "Alert on changing IAM policy"
+      event_pattern = jsonencode(
+        {
+          "source" : ["aws.iam"],
+          "detail-type" : ["AWS API Call via CloudTrail"],
+          "detail" : {
+            "eventSource" : ["iam.amazonaws.com"],
+            "eventName" : [
+              "DeleteGroupPolicy",
+              "DeleteRolePolicy",
+              "DeleteUserPolicy",
+              "PutGroupPolicy",
+              "PutRolePolicy",
+              "PutUserPolicy",
+              "CreatePolicy",
+              "DeletePolicy",
+              "CreatePolicyVersion",
+              "DeletePolicyVersion",
+              "AttachRolePolicy",
+              "DetachRolePolicy",
+              "AttachUserPolicy",
+              "DetachUserPolicy",
+              "AttachGroupPolicy",
+              "DetachGroupPolicy"
+            ]
+          }
+        }
+      )
+    },
+    cloudtrail_configuration_changes = {
+      enabled     = var.aws_cis_benchmark_alerts.rules.cloudtrail_configuration_changes_enabled
+      description = "Alert on changing Cloudtrail configuration"
+      event_pattern = jsonencode(
+        {
+          "source" : ["aws.cloudtrail"],
+          "detail-type" : ["AWS API Call via CloudTrail"],
+          "detail" : {
+            "eventSource" : ["cloudtrail.amazonaws.com"],
+            "eventName" : [
+              "CreateTrail",
+              "UpdateTrail",
+              "DeleteTrail",
+              "StartLogging",
+              "StopLogging"
+            ]
+          }
+        }
+      )
+    },
+    s3_bucket_policy_changes = {
+      enabled     = var.aws_cis_benchmark_alerts.rules.s3_bucket_policy_changes_enabled
+      description = "Alert on changing s3 bucket policy"
+      event_pattern = jsonencode(
+        {
+          "source" : ["aws.s3"],
+          "detail-type" : ["AWS API Call via CloudTrail"],
+          "detail" : {
+            "eventSource" : ["s3.amazonaws.com"],
+            "eventName" : [
+              "PutBucketAcl",
+              "PutBucketPolicy",
+              "PutBucketCors",
+              "PutBucketLifecycle",
+              "PutBucketReplication",
+              "DeleteBucketPolicy",
+              "DeleteBucketCors",
+              "DeleteBucketLifecycle",
+              "DeleteBucketReplication"
+            ]
+          }
+        }
+      )
+    },
+    aws_config_changes = {
+      enabled     = var.aws_cis_benchmark_alerts.rules.aws_config_changes_enabled
+      description = "Alert on changing AWS Config configuration"
+      event_pattern = jsonencode(
+        {
+          "source" : ["aws.config"],
+          "detail-type" : ["AWS API Call via CloudTrail"],
+          "detail" : {
+            "eventSource" : ["config.amazonaws.com"],
+            "eventName" : [
+              "StopConfigurationRecorder",
+              "DeleteDeliveryChannel",
+              "PutDeliveryChannel",
+              "PutConfigurationRecorder"
+            ]
+          }
+        }
+      )
+    },
+    security_group_changes = {
+      enabled     = var.aws_cis_benchmark_alerts.rules.security_group_changes_enabled
+      description = "Alert on changing Security groups"
+      event_pattern = jsonencode(
+        {
+          "source" : ["aws.ec2"],
+          "detail-type" : ["AWS API Call via CloudTrail"],
+          "detail" : {
+            "eventSource" : ["ec2.amazonaws.com"],
+            "eventName" : [
+              "AuthorizeSecurityGroupIngress",
+              "AuthorizeSecurityGroupEgress",
+              "RevokeSecurityGroupIngress",
+              "RevokeSecurityGroupEgress",
+              "CreateSecurityGroup",
+              "DeleteSecurityGroup"
+            ]
+          }
+        }
+      )
+    },
+    nacl_changes = {
+      enabled     = var.aws_cis_benchmark_alerts.rules.nacl_changes_enabled
+      description = "Alert on changing NACL"
+      event_pattern = jsonencode(
+        {
+          "source" : ["aws.ec2"],
+          "detail-type" : ["AWS API Call via CloudTrail"],
+          "detail" : {
+            "eventSource" : ["ec2.amazonaws.com"],
+            "eventName" : [
+              "CreateNetworkAcl",
+              "CreateNetworkAclEntry",
+              "DeleteNetworkAcl",
+              "DeleteNetworkAclEntry",
+              "ReplaceNetworkAclEntry",
+              "ReplaceNetworkAclAssociation"
+            ]
+          }
+        }
+      )
+    },
+    network_gateway_changes = {
+      enabled     = var.aws_cis_benchmark_alerts.rules.network_gateway_changes_enabled
+      description = "Alert on changing Network Gateways"
+      event_pattern = jsonencode(
+        {
+          "source" : ["aws.ec2"],
+          "detail-type" : ["AWS API Call via CloudTrail"],
+          "detail" : {
+            "eventSource" : ["ec2.amazonaws.com"],
+            "eventName" : [
+              "CreateCustomerGateway",
+              "DeleteCustomerGateway",
+              "AttachInternetGateway",
+              "CreateInternetGateway",
+              "DeleteInternetGateway",
+              "DetachInternetGateway"
+            ]
+          }
+        }
+      )
+    },
+    route_table_changes = {
+      enabled     = var.aws_cis_benchmark_alerts.rules.route_table_changes_enabled
+      description = "Alert on changing Route tables"
+      event_pattern = jsonencode(
+        {
+          "source" : ["aws.ec2"],
+          "detail-type" : ["AWS API Call via CloudTrail"],
+          "detail" : {
+            "eventSource" : ["ec2.amazonaws.com"],
+            "eventName" : [
+              "CreateRoute",
+              "CreateRouteTable",
+              "ReplaceRoute",
+              "ReplaceRouteTableAssociation",
+              "DeleteRouteTable",
+              "DeleteRoute",
+              "DisassociateRouteTable"
+            ]
+          }
+        }
+      )
+    },
+    vpc_changes = {
+      enabled     = var.aws_cis_benchmark_alerts.rules.vpc_changes_enabled
+      description = "Alert on changing VPC configuration"
+      event_pattern = jsonencode(
+        {
+          "source" : ["aws.ec2"],
+          "detail-type" : ["AWS API Call via CloudTrail"],
+          "detail" : {
+            "eventSource" : ["ec2.amazonaws.com"],
+            "eventName" : [
+              "CreateVpc",
+              "DeleteVpc",
+              "ModifyVpcAttribute",
+              "AcceptVpcPeeringConnection",
+              "CreateVpcPeeringConnection",
+              "DeleteVpcPeeringConnection",
+              "RejectVpcPeeringConnection",
+              "AttachClassicLinkVpc",
+              "DetachClassicLinkVpc",
+              "DisableVpcClassicLink",
+              "EnableVpcClassicLink"
+            ]
+          }
+        }
+      )
+    },
+    organization_changes = {
+      enabled     = var.aws_cis_benchmark_alerts.rules.organization_changes_enabled
+      description = "Alert on Organization changes"
+      event_pattern = jsonencode(
+        {
+          "source" : ["aws.organizations"],
+          "detail-type" : ["AWS API Call via CloudTrail"],
+          "detail" : {
+            "eventSource" : ["organizations.amazonaws.com"],
+            "eventName" : [
+              "AcceptHandshake",
+              "AttachPolicy",
+              "CreateAccount",
+              "CreateOrganizationalUnit",
+              "CreatePolicy",
+              "DeclineHandshake",
+              "DeleteOrganization",
+              "DeleteOrganizationalUnit",
+              "DeletePolicy",
+              "DetachPolicy",
+              "DisablePolicyType",
+              "EnablePolicyType",
+              "InviteAccountToOrganization",
+              "LeaveOrganization",
+              "MoveAccount",
+              "RemoveAccountFromOrganization",
+              "UpdatePolicy",
+              "UpdateOrganizationalUnit"
+            ]
+          }
+        }
+      )
+    },
+  }
+
+  targets = {
+    secrets_manager_actions = [
+      {
+        name = "secrets-manager-actions-notify-via-sns"
+        arn  = aws_sns_topic.security_alerts[count.index].arn
+      }
+    ],
+    parameter_store_actions = [
+      {
+        name = "parameter-store-actions-notify-via-sns"
+        arn  = aws_sns_topic.security_alerts[count.index].arn
+      }
+    ],
+    console_login_failed = [
+      {
+        name = "console-login-failed-notify-via-sns"
+        arn  = aws_sns_topic.security_alerts[count.index].arn
+      }
+    ],
+    kms_cmk_delete_or_disable = [
+      {
+        name = "kms-cmk-delete-or-disable-notify-via-sns"
+        arn  = aws_sns_topic.security_alerts[count.index].arn
+      }
+    ]
+    consolelogin_without_mfa = [
+      {
+        name = "consolelogin-without-mfa-notify-via-sns"
+        arn  = aws_sns_topic.security_alerts[count.index].arn
+      }
+    ],
+    unauthorized_api_calls = [
+      {
+        name = "unauthorized-api-calls-notify-via-sns"
+        arn  = aws_sns_topic.security_alerts[count.index].arn
+      }
+    ],
+    usage_of_root_account = [
+      {
+        name = "usage-of-root-account-notify-via-sns"
+        arn  = aws_sns_topic.security_alerts[count.index].arn
+      }
+    ],
+    iam_policy_changes = [
+      {
+        name = "iam-policy-changes-notify-via-sns"
+        arn  = aws_sns_topic.security_alerts[count.index].arn
+      }
+    ],
+    cloudtrail_configuration_changes = [
+      {
+        name = "cloudtrail-configuration-changes-notify-via-sns"
+        arn  = aws_sns_topic.security_alerts[count.index].arn
+      }
+    ],
+    s3_bucket_policy_changes = [
+      {
+        name = "s3-bucket-policy-changes-notify-via-sns"
+        arn  = aws_sns_topic.security_alerts[count.index].arn
+      }
+    ],
+    aws_config_changes = [
+      {
+        name = "aws-config-changes-notify-via-sns"
+        arn  = aws_sns_topic.security_alerts[count.index].arn
+      }
+    ],
+    security_group_changes = [
+      {
+        name = "security-group-changes-notify-via-sns"
+        arn  = aws_sns_topic.security_alerts[count.index].arn
+      }
+    ],
+    nacl_changes = [
+      {
+        name = "nacl-changes-notify-via-sns"
+        arn  = aws_sns_topic.security_alerts[count.index].arn
+      }
+    ],
+    network_gateway_changes = [
+      {
+        name = "network-gateway-changes-notify-via-sns"
+        arn  = aws_sns_topic.security_alerts[count.index].arn
+      }
+    ],
+    route_table_changes = [
+      {
+        name = "route-table-changes-notify-via-sns"
+        arn  = aws_sns_topic.security_alerts[count.index].arn
+      }
+    ],
+    vpc_changes = [
+      {
+        name = "vpc-changes-notify-via-sns"
+        arn  = aws_sns_topic.security_alerts[count.index].arn
+      }
+    ],
+    organization_changes = [
+      {
+        name = "organization-changes-notify-via-sns"
+        arn  = aws_sns_topic.security_alerts[count.index].arn
+      }
+    ]
+  }
+}
+

--- a/terraform/layer1-aws/aws-s3.tf
+++ b/terraform/layer1-aws/aws-s3.tf
@@ -1,0 +1,72 @@
+##################
+# Cloudtrail
+##################
+resource "aws_s3_bucket" "cloudtrail" {
+  bucket = "${local.name}-aws-cloudtrail-logs"
+
+  tags = local.tags
+}
+
+resource "aws_s3_bucket_acl" "cloudtrail" {
+  bucket = aws_s3_bucket.cloudtrail.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "cloudtrail" {
+  bucket = aws_s3_bucket.cloudtrail.id
+
+  rule {
+    id     = "remove_old_files"
+    status = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 2
+    }
+    expiration {
+      days = var.cloudtrail_logs_s3_expiration_days
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "cloudtrail" {
+  bucket                  = aws_s3_bucket.cloudtrail.id
+  restrict_public_buckets = true
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+}
+
+resource "aws_s3_bucket_policy" "cloudtrail" {
+  bucket = aws_s3_bucket.cloudtrail.id
+
+  policy = jsonencode(
+    {
+      "Version" : "2012-10-17",
+      "Statement" : [
+        {
+          "Sid" : "AWSCloudTrailAclCheck",
+          "Effect" : "Allow",
+          "Principal" : {
+            "Service" : "cloudtrail.amazonaws.com"
+          },
+          "Action" : "s3:GetBucketAcl",
+          "Resource" : aws_s3_bucket.cloudtrail.arn
+        },
+        {
+          "Sid" : "AWSCloudTrailWrite",
+          "Effect" : "Allow",
+          "Principal" : {
+            "Service" : "cloudtrail.amazonaws.com"
+          },
+          "Action" : "s3:PutObject",
+          "Resource" : "${aws_s3_bucket.cloudtrail.arn}/*",
+          "Condition" : {
+            "StringEquals" : {
+              "s3:x-amz-acl" : "bucket-owner-full-control"
+            }
+          }
+        }
+      ]
+  })
+}
+####################

--- a/terraform/layer1-aws/aws-sns.tf
+++ b/terraform/layer1-aws/aws-sns.tf
@@ -1,0 +1,58 @@
+#tfsec:ignore:aws-sns-enable-topic-encryption
+resource "aws_sns_topic" "security_alerts" {
+  count = var.aws_cis_benchmark_alerts.enabled ? 1 : 0
+
+  name = "${local.name}-security-alerts"
+}
+
+resource "aws_sns_topic_subscription" "security_alerts" {
+  count = var.aws_cis_benchmark_alerts.enabled ? 1 : 0
+
+  topic_arn = aws_sns_topic.security_alerts[count.index].arn
+  protocol  = "email"
+  endpoint  = var.aws_cis_benchmark_alerts.email
+}
+
+resource "aws_sns_topic_policy" "security_alerts" {
+  count = var.aws_cis_benchmark_alerts.enabled ? 1 : 0
+
+  arn = aws_sns_topic.security_alerts[count.index].arn
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Sid" : "Allow_Publish_Events",
+        "Effect" : "Allow",
+        "Principal" : { "Service" : "events.amazonaws.com" },
+        "Action" : "sns:Publish",
+        "Resource" : [
+          aws_sns_topic.security_alerts[count.index].arn
+        ]
+      },
+      {
+        "Sid" : "__default_statement_ID",
+        "Effect" : "Allow",
+        "Principal" : { "AWS" : "*" },
+        "Action" : [
+          "sns:GetTopicAttributes",
+          "sns:SetTopicAttributes",
+          "sns:AddPermission",
+          "sns:RemovePermission",
+          "sns:DeleteTopic",
+          "sns:Subscribe",
+          "sns:ListSubscriptionsByTopic",
+          "sns:Publish",
+          "sns:Receive"
+        ]
+        "Resource" : [
+          aws_sns_topic.security_alerts[count.index].arn
+        ]
+        "Condition" : {
+          "StringEquals" : {
+            "AWS:SourceOwner" : data.aws_caller_identity.current.account_id
+          }
+        }
+      }
+    ]
+  })
+}

--- a/terraform/layer1-aws/aws-sns.tf
+++ b/terraform/layer1-aws/aws-sns.tf
@@ -3,6 +3,8 @@ resource "aws_sns_topic" "security_alerts" {
   count = var.aws_cis_benchmark_alerts.enabled ? 1 : 0
 
   name = "${local.name}-security-alerts"
+
+  tags = local.tags
 }
 
 resource "aws_sns_topic_subscription" "security_alerts" {

--- a/terraform/layer1-aws/variables.tf
+++ b/terraform/layer1-aws/variables.tf
@@ -305,3 +305,31 @@ variable "pritunl_vpn_access_cidr_blocks" {
   default     = "127.0.0.1/32"
   description = "IP address that will have access to the web console"
 }
+
+variable "aws_cis_benchmark_alerts" {
+  type = any
+  default = {
+    "enabled" = "false"
+    "email"   = "demo@example.com" # where to send alerts
+    "rules" = {
+      "secrets_manager_actions_enabled"          = true
+      "parameter_store_actions_enabled"          = true
+      "console_login_failed_enabled"             = true
+      "kms_cmk_delete_or_disable_enabled"        = true
+      "consolelogin_without_mfa_enabled"         = true
+      "unauthorized_api_calls_enabled"           = true
+      "usage_of_root_account_enabled"            = true
+      "iam_policy_changes_enabled"               = true
+      "cloudtrail_configuration_changes_enabled" = true
+      "s3_bucket_policy_changes_enabled"         = true
+      "aws_config_changes_enabled"               = true
+      "security_group_changes_enabled"           = true
+      "nacl_changes_enabled"                     = true
+      "network_gateway_changes_enabled"          = true
+      "route_table_changes_enabled"              = true
+      "vpc_changes_enabled"                      = true
+      "organization_changes_enabled"             = true
+    }
+  }
+  description = "AWS CIS Benchmark alerts configuration"
+}

--- a/terraform/layer1-aws/variables.tf
+++ b/terraform/layer1-aws/variables.tf
@@ -333,3 +333,9 @@ variable "aws_cis_benchmark_alerts" {
   }
   description = "AWS CIS Benchmark alerts configuration"
 }
+
+variable "cloudtrail_logs_s3_expiration_days" {
+  type        = string
+  default     = 180
+  description = "How many days keep cloudtrail logs on S3"
+}


### PR DESCRIPTION
# PR Description

* Added possibility to notify via email about some changes in infrastructure (based on AWS [CIS Benchmark](https://docs.aws.amazon.com/config/latest/developerguide/operational-best-practices-for-cis_aws_benchmark_level_2.html), control ID: 4.1-4.15). Disabled by default.

A scheme looks like:

<img width="770" alt="image" src="https://user-images.githubusercontent.com/37855803/167071183-2169bef3-726b-47b5-9368-a1708455756e.png">

* Added Cloudtrail configuration because some alerts require configured Trail (for example - events from Secrets Manager)
* Wasn't able to use https://github.com/terraform-aws-modules/terraform-aws-s3-bucket to create bucket. The latest available version has political slogan. The latest version without political slogans is [v2.14.1](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/releases/tag/v2.14.1). However, it requires an AWS provider version ~> 3.69. We've recently updated aws provider to "4.10.0". That's why I created "raw" terraform resource to describe the s3 bucket configuration.
* Sonarcube and tfsec complain about SNS resource-based policy. However, it has condition + this is a default attached policy when you try to create SNS topic via AWS UI. 
* An example of received alerts:
```
{"version":"0","id":"**************c","detail-type":"AWS API Call via CloudTrail","source":"aws.secretsmanager","account":"********","time":"2022-05-06T06:44:25Z","region":"us-east-1","resources":[],"detail":{"eventVersion":"1.08","userIdentity":{"type":"AssumedRole","principalId":"****:[******](mailto:******)","arn":"arn:aws:sts::******:[assumed-role/******/********](mailto:assumed-role/*******/*********)","accountId":"*********","accessKeyId":"**********","sessionContext":{"sessionIssuer":{"type":"Role","principalId":"**********","arn":"arn:aws:iam::**********:role/*********","accountId":"**********","userName":"********"},"webIdFederationData":{},"attributes":{"creationDate":"2022-05-06T06:11:53Z","mfaAuthenticated":"true"}}},"eventTime":"2022-05-06T06:44:25Z","eventSource":"[secretsmanager.amazonaws.com](http://secretsmanager.amazonaws.com/)","eventName":"PutSecretValue","awsRegion":"us-east-1","sourceIPAddress":"AWS Internal","userAgent":"AWS Internal","requestParameters":{"clientRequestToken":"*********","secretId":"arn:aws:secretsmanager:us-east-1:**********:secret:/***********"},"responseElements":{"arn":"arn:aws:secretsmanager:us-east-1:******:secret:/*********"},"requestID":"********","eventID":"************","readOnly":false,"eventType":"AwsApiCall","managementEvent":true,"recipientAccountId":"********","eventCategory":"Management","sessionCredentialFromConsole":"true"}}
```

Fixes #281 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
