### PR TITLE
bug: fix aws-cluster-autoscaler expander priorities configuration

### DIFF
--- a/terraform/layer2-k8s/eks-cluster-autoscaler.tf
+++ b/terraform/layer2-k8s/eks-cluster-autoscaler.tf
@@ -24,9 +24,9 @@ extraArgs:
   expander: priority
 expanderPriorities: |
   10:
-    - eks-${local.eks_cluster_id}-ondemand.*
+    - ${local.eks_cluster_id}-ondemand.*
   50:
-    - eks-${local.eks_cluster_id}-spot.*
+    - ${local.eks_cluster_id}-spot.*
 
 serviceMonitor:
   enabled: true


### PR DESCRIPTION
# PR Description

Fixed aws-cluster-autoscaler expander configuration. We switched back to self-managed nodegroups, but forgot to change aws-cluster-autoscaler configuration

Fixes #291

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
