### PR TITLE
enh: use aws-load-balancer-controller in front of ingress-nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,13 +396,16 @@ terragrunt destroy
 
 ## What to do after deployment
 
-After applying this configuration, you will get the infrastructure described and outlined at the beginning of the document. In AWS and within the EKS cluster, the basic resources and services necessary for the operation of the EKS k8s cluster will be created.
+* After applying this configuration, you will get the infrastructure described and outlined at the beginning of the document. In AWS and within the EKS cluster, the basic resources and services necessary for the operation of the EKS k8s cluster will be created (except configuration for Route53).
 
-You can get access to the cluster using this command:
+* You can get access to the cluster using this command:
 
   ```bash
   aws eks update-kubeconfig --name maddevs-demo-use1 --region us-east-1
   ```
+
+* If you used default configuration and want to serve traffic for a main domain (example.com) by an application deployed into a k8s cluster, youn need to manually create DNS record in Route53 with type A + Alias
+* DNS record `*.example.com` created automatically and points to Load Balancer in front of k8s cluster. 
 
 ## Update terraform version
 

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ terragrunt destroy
 
 ## What to do after deployment
 
-* After applying this configuration, you will get the infrastructure described and outlined at the beginning of the document. In AWS and within the EKS cluster, the basic resources and services necessary for the operation of the EKS k8s cluster will be created (except configuration for Route53).
+* After applying this configuration, you will get the infrastructure described and outlined at the beginning of the document. In AWS and within the EKS cluster, the basic resources and services necessary for the operation of the EKS k8s cluster will be created.
 
 * You can get access to the cluster using this command:
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -304,3 +304,10 @@ kubectl delete installations.operator.tigera.io default
 kubectl delete ns calico-apiserver calico-system
 ```
 5. Restart all nodes
+
+## What if you don't want to use an aws-load-balancer controller in front of an ingress-nginx and want to use a cert-manager and terminate SSL on ingres-nginx side
+
+1. Set `nginx ` for a `nginx_ingress_ssl_terminator` variable in the layer2-k8s folder
+2. Set `enabled: false` for `id: aws-load-balancer-controller` in the **layer2-k8s/helm-releases.yaml** file
+3. Set `enabled: true` for `id: external-dns`, `id: cert-manager`, `id: cert-mananger-certificate`, `id:cert-manager-cluster-issuer` in the **layer2-k8s/helm-releases.yaml** file
+4. Run `terraform apply` in the layer2-k8s folder

--- a/terraform/layer2-k8s/README.md
+++ b/terraform/layer2-k8s/README.md
@@ -21,6 +21,7 @@
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.10.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.1.3 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 3.3.0 |
 
 ## Modules
 
@@ -86,6 +87,7 @@
 | [kubectl_manifest.istio_prometheus_service_monitor_cp](https://registry.terraform.io/providers/gavinbunney/kubectl/1.14.0/docs/resources/manifest) | resource |
 | [kubectl_manifest.istio_prometheus_service_monitor_dp](https://registry.terraform.io/providers/gavinbunney/kubectl/1.14.0/docs/resources/manifest) | resource |
 | [kubectl_manifest.kube_prometheus_stack_operator_crds](https://registry.terraform.io/providers/gavinbunney/kubectl/1.14.0/docs/resources/manifest) | resource |
+| [kubernetes_ingress_v1.default](https://registry.terraform.io/providers/kubernetes/2.10.0/docs/resources/ingress_v1) | resource |
 | [kubernetes_secret.elasticsearch_certificates](https://registry.terraform.io/providers/kubernetes/2.10.0/docs/resources/secret) | resource |
 | [kubernetes_secret.elasticsearch_credentials](https://registry.terraform.io/providers/kubernetes/2.10.0/docs/resources/secret) | resource |
 | [kubernetes_secret.elasticsearch_s3_user_creds](https://registry.terraform.io/providers/kubernetes/2.10.0/docs/resources/secret) | resource |
@@ -96,6 +98,11 @@
 | [random_string.kibana_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [random_string.kube_prometheus_stack_grafana_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [random_string.victoria_metrics_k8s_stack_grafana_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [tls_cert_request.aws_loadbalancer_controller_webhook](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/cert_request) | resource |
+| [tls_locally_signed_cert.aws_loadbalancer_controller_webhook](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/locally_signed_cert) | resource |
+| [tls_private_key.aws_loadbalancer_controller_webhook](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [tls_private_key.aws_loadbalancer_controller_webhook_ca](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [tls_self_signed_cert.aws_loadbalancer_controller_webhook_ca](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/self_signed_cert) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/aws/4.10.0/docs/data-sources/caller_identity) | data source |
 | [aws_eks_cluster.main](https://registry.terraform.io/providers/aws/4.10.0/docs/data-sources/eks_cluster) | data source |
 | [aws_eks_cluster_auth.main](https://registry.terraform.io/providers/aws/4.10.0/docs/data-sources/eks_cluster_auth) | data source |

--- a/terraform/layer2-k8s/README.md
+++ b/terraform/layer2-k8s/README.md
@@ -59,6 +59,7 @@
 
 | Name | Type |
 |------|------|
+| [aws_route53_record.default_ingress](https://registry.terraform.io/providers/aws/4.10.0/docs/resources/route53_record) | resource |
 | [aws_s3_bucket.elastic_stack](https://registry.terraform.io/providers/aws/4.10.0/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.gitlab_runner_cache](https://registry.terraform.io/providers/aws/4.10.0/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_public_access_block.elastic_stack_public_access_block](https://registry.terraform.io/providers/aws/4.10.0/docs/resources/s3_bucket_public_access_block) | resource |

--- a/terraform/layer2-k8s/eks-aws-loadbalancer-controller.tf
+++ b/terraform/layer2-k8s/eks-aws-loadbalancer-controller.tf
@@ -432,7 +432,7 @@ resource "kubernetes_ingress_v1" "default" {
       "alb.ingress.kubernetes.io/listen-ports"             = "[{\"HTTP\": 80}, {\"HTTPS\": 443}]"
       "alb.ingress.kubernetes.io/target-type"              = "ip"
       "alb.ingress.kubernetes.io/load-balancer-attributes" = "routing.http2.enabled=true"
-      "alb.ingress.kubernetes.io/actions.ssl-redirect"     = "{\"Type\": \"redirect\", \"RedirectConfig\": { \"Protocol\": \"HTTPS\", \"Port\": \"443\", \"StatusCode\": \"HTTP_302\"}}"
+      "alb.ingress.kubernetes.io/ssl-redirect"             = "443"
     }
     namespace = module.ingress_nginx_namespace[count.index].name
   }

--- a/terraform/layer2-k8s/helm-releases.yaml
+++ b/terraform/layer2-k8s/helm-releases.yaml
@@ -1,6 +1,6 @@
 releases:
   - id: aws-load-balancer-controller
-    enabled: false
+    enabled: true
     chart: aws-load-balancer-controller
     repository: https://aws.github.io/eks-charts
     chart_version: 1.4.1
@@ -42,7 +42,7 @@ releases:
     chart_version:
     namespace: elk
   - id: external-dns
-    enabled: true
+    enabled: false
     chart: external-dns
     repository: https://kubernetes-sigs.github.io/external-dns
     chart_version: 1.9.0


### PR DESCRIPTION
# PR Description

* Enabled aws-load-balancer-controller by default
* Changed ingress-nginx service type from LoadBalancer to ClusterIP by default
* Disabled external-dns by default
* Generated SSL certificates for aws-load-balancer-controller due to this [issue](https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2312)
* Updated FAQ.md with notes on how to terminate SSL on ingress-nginx side (use cert-manager)

New default scheme looks like:
<img width="939" alt="image" src="https://user-images.githubusercontent.com/37855803/169493665-16a5c21a-ae32-4f51-8694-63c463c7b561.png">

Pros:
* we can use WAF without using Cloudfront
* we can use WebSockets

Cons:
* can be used only for http traffic

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
