### PR TITLE
doc: disable gitlab clusterwide default access

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -221,6 +221,13 @@ runners:
         ...
 ...
 ```
+* Disable cluster-wide access for the default Service Account:
+```
+...
+rbac:
+  clusterWideAccess: false
+...
+```
 
 ## Monitoring
 This boilerplate provides two solutions for monitoring: 


### PR DESCRIPTION
# PR Description

* disable gitlab cluster-wide default access in case of use additional Service Account for runners

## Type of change
- [*] Documentation update

# Checklist

- [*] My code follows the style guidelines of this project
- [*] I have performed a self-review of my own code
- [*] I have commented my code, particularly in hard-to-understand areas
- [*] I have made corresponding changes to the documentation
