### PR TITLE
fix: set k8s resources for Loki workload

### DIFF
--- a/terraform/layer2-k8s/eks-loki-stack.tf
+++ b/terraform/layer2-k8s/eks-loki-stack.tf
@@ -13,6 +13,13 @@ loki:
   rbac:
     create: true
     pspEnabled: false # Due to psp removed in k8s 1.25 and latest loki-stack chart doesn't maintain new PSP version
+  resources:
+    limits:
+      cpu: 1
+      memory: 1Gi
+    requests:
+      cpu: 500m
+      memory: 1Gi
   config:
     limits_config:
       enforce_metric_name: false


### PR DESCRIPTION
# PR Description

Set resources for Loki, otherwise it uses values from LimitRange configuration and it isn't enough. 

Fixes #318 

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
