### PR TITLE
fix: change authentication method for cloudwatch datasource

### DIFF
--- a/terraform/layer2-k8s/eks-kube-prometheus-stack.tf
+++ b/terraform/layer2-k8s/eks-kube-prometheus-stack.tf
@@ -128,7 +128,6 @@ grafana:
         - name: CloudWatch
           type: cloudwatch
           jsonData:
-            authType: credentials
             defaultRegion: "${local.region}"
         - name: Loki
           type: loki


### PR DESCRIPTION
# PR Description

To use the outside role, you must use the aws sdk. This method is used by default.

Fixes # (https://github.com/maddevsio/aws-eks-base/issues/343)

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
