### PR TITLE
fix: some fixes for karpenter deploy

### DIFF
--- a/terraform/modules/k8s-karpenter/main.tf
+++ b/terraform/modules/k8s-karpenter/main.tf
@@ -19,12 +19,6 @@ serviceAccount:
   annotations:
     eks.amazonaws.com/role-arn: ${module.this[0].iam_role_arn}
 
-postInstallHook:
-  image:
-    repository: bitnami/kubectl
-    tag: "1.30"
-    digest: sha256:c85f429088cea9ad968752e6d59e7edbc74b5750526f9a04531dce6b37f3ac87
-
 controller:
   resources:
     requests:

--- a/terraform/modules/k8s-karpenter/main.tf
+++ b/terraform/modules/k8s-karpenter/main.tf
@@ -5,7 +5,7 @@ locals {
     enabled       = true
     chart         = try(var.helm.chart_name, "oci://public.ecr.aws/karpenter/karpenter")
     repository    = try(var.helm.repository, "")
-    chart_version = try(var.helm.chart_version, "1.0.0")
+    chart_version = try(var.helm.chart_version, "1.0.3")
     namespace     = try(var.helm.namespace, "karpenter")
   }
 

--- a/terragrunt/ACCOUNT_ID/us-east-1/demo/common/aws-eks/.terraform.lock.hcl
+++ b/terragrunt/ACCOUNT_ID/us-east-1/demo/common/aws-eks/.terraform.lock.hcl
@@ -3,8 +3,9 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.58.0"
-  constraints = "5.58.0"
+  constraints = ">= 4.0.0, >= 4.33.0, >= 5.58.0, 5.58.0"
   hashes = [
+    "h1:6vsFc7SmmlElqg3k0X6azrO0yarM7UPCUF4XsAYryjA=",
     "h1:XnAwb/MGeP7sxz/0SKLQF1ujaP7Bg15ol+ca7KZruio=",
     "zh:15e9be54a8febe8e560362b10967cb60b680ca3f78fe207d7209b76e076f59d3",
     "zh:240f6899a2cec259aa2729ce031f6af2b453f90a8b59118bb2571c54acc65db8",
@@ -29,6 +30,7 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   constraints = ">= 2.0.0"
   hashes = [
     "h1:S3j8poSaLbaftlKq2STBkQEkZH253ZLaHhBHBifdpBQ=",
+    "h1:cVIIhnXweOHavu1uV2bdKScTjLbM1WnKM/25wqYBJWo=",
     "zh:09f1f1e1d232da96fbf9513b0fb5263bc2fe9bee85697aa15d40bb93835efbeb",
     "zh:381e74b90d7a038c3a8dcdcc2ce8c72d6b86da9f208a27f4b98cabe1a1032773",
     "zh:398eb321949e28c4c5f7c52e9b1f922a10d0b2b073b7db04cb69318d24ffc5a9",
@@ -49,6 +51,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   constraints = "2.30.0"
   hashes = [
     "h1:+Je5UPTWMmO4eG5ep1WfujkXQI9tDk0OsMU4olU76Bg=",
+    "h1:wRVWY3sK32BNInDOlQnoGSmL638f3jjLFypCAotwpc8=",
     "zh:06531333a72fe6d2829f37a328e08a3fc4ed66226344a003b62418a834ac6c69",
     "zh:34480263939ef5007ce65c9f4945df5cab363f91e5260ae552bcd9f2ffeed444",
     "zh:59e71f9177da570c33507c44828288264c082d512138c5755800f2cd706c62bc",
@@ -70,6 +73,7 @@ provider "registry.terraform.io/hashicorp/null" {
   hashes = [
     "h1:IMVAUHKoydFrlPrl9OzasDnw/8ntZFerCC9iXw1rXQY=",
     "h1:vWAsYRd7MjYr3adj8BVKRohVfHpWQdvkIwUQ2Jf5FVM=",
+    "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
     "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
     "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
     "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",
@@ -87,8 +91,9 @@ provider "registry.terraform.io/hashicorp/null" {
 
 provider "registry.terraform.io/hashicorp/time" {
   version     = "0.11.2"
-  constraints = "0.11.2"
+  constraints = ">= 0.9.0"
   hashes = [
+    "h1:bC4b7n4g30ciIn5w6b66mXSTIo2CH6XQbp+gBdDvlYs=",
     "h1:qg3O4PmHnlPcvuZ2LvzOYEAPGOKtccgD5kPdQPZw094=",
     "zh:02588b5b8ba5d31e86d93edc93b306bcbf47c789f576769245968cc157a9e8c5",
     "zh:088a30c23796133678d1d6614da5cf5544430570408a17062288b58c0bd67ac8",
@@ -109,6 +114,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   version     = "4.0.5"
   constraints = ">= 3.0.0"
   hashes = [
+    "h1:e4LBdJoZJNOQXPWgOAG0UuPBVhCStu98PieNlqJTmeU=",
     "h1:yLqz+skP3+EbU3yyvw8JqzflQTKDQGsC9QyZAg+S4dg=",
     "h1:zeG5RmggBZW/8JWIVrdaeSJa0OG62uFX5HY1eE8SjzY=",
     "zh:01cfb11cb74654c003f6d4e32bbef8f5969ee2856394a96d127da4949c65153e",

--- a/terragrunt/ACCOUNT_ID/us-east-1/demo/common/aws-vpc/.terraform.lock.hcl
+++ b/terragrunt/ACCOUNT_ID/us-east-1/demo/common/aws-vpc/.terraform.lock.hcl
@@ -3,8 +3,9 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.58.0"
-  constraints = "5.58.0"
+  constraints = ">= 5.30.0, 5.58.0"
   hashes = [
+    "h1:6vsFc7SmmlElqg3k0X6azrO0yarM7UPCUF4XsAYryjA=",
     "h1:XnAwb/MGeP7sxz/0SKLQF1ujaP7Bg15ol+ca7KZruio=",
     "zh:15e9be54a8febe8e560362b10967cb60b680ca3f78fe207d7209b76e076f59d3",
     "zh:240f6899a2cec259aa2729ce031f6af2b453f90a8b59118bb2571c54acc65db8",

--- a/terragrunt/ACCOUNT_ID/us-east-1/demo/env.yaml
+++ b/terragrunt/ACCOUNT_ID/us-east-1/demo/env.yaml
@@ -28,6 +28,8 @@ eks_karpenter_nodepools:
 
         spec:
           nodeClassRef:
+            group: karpenter.k8s.aws
+            kind: EC2NodeClass
             name: private
 
           requirements:
@@ -68,6 +70,7 @@ eks_karpenter_nodepools:
 
       disruption:
         consolidationPolicy: WhenEmptyOrUnderutilized
+        consolidateAfter: 1m
 
       limits:
         cpu: "1000"
@@ -85,6 +88,8 @@ eks_karpenter_nodepools:
 
         spec:
           nodeClassRef:
+            group: karpenter.k8s.aws
+            kind: EC2NodeClass
             name: public
 
           taints:
@@ -130,6 +135,7 @@ eks_karpenter_nodepools:
 
       disruption:
         consolidationPolicy: WhenEmptyOrUnderutilized
+        consolidateAfter: 1m
 
       limits:
         cpu: "1000"

--- a/terragrunt/ACCOUNT_ID/us-east-1/demo/karpenter/.terraform.lock.hcl
+++ b/terragrunt/ACCOUNT_ID/us-east-1/demo/karpenter/.terraform.lock.hcl
@@ -1,9 +1,12 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/gavinbunney/kubectl" {
   version     = "1.14.0"
   constraints = "1.14.0"
   hashes = [
     "h1:ItrWfCZMzM2JmvDncihBMalNLutsAk7kyyxVRaipftY=",
+    "h1:gLFn+RvP37sVzp9qnFCwngRjjFV649r6apjxvJ1E/SE=",
     "zh:0350f3122ff711984bbc36f6093c1fe19043173fad5a904bce27f86afe3cc858",
     "zh:07ca36c7aa7533e8325b38232c77c04d6ef1081cb0bac9d56e8ccd51f12f2030",
     "zh:0c351afd91d9e994a71fe64bbd1662d0024006b3493bb61d46c23ea3e42a7cf5",
@@ -18,8 +21,9 @@ provider "registry.terraform.io/gavinbunney/kubectl" {
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.58.0"
-  constraints = "5.58.0"
+  constraints = ">= 5.57.0, 5.58.0"
   hashes = [
+    "h1:6vsFc7SmmlElqg3k0X6azrO0yarM7UPCUF4XsAYryjA=",
     "h1:XnAwb/MGeP7sxz/0SKLQF1ujaP7Bg15ol+ca7KZruio=",
     "zh:15e9be54a8febe8e560362b10967cb60b680ca3f78fe207d7209b76e076f59d3",
     "zh:240f6899a2cec259aa2729ce031f6af2b453f90a8b59118bb2571c54acc65db8",
@@ -44,6 +48,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   constraints = "2.13.2"
   hashes = [
     "h1:KHLdE3Xb4XbLCWwCSArYcXulYyBJKTFizaIzBiYVJxQ=",
+    "h1:nlSqCo0PajJzjSlx0lXNUq1YcOr8p9b3ahcUUYN2pEg=",
     "zh:06c0663031ef5aa19e238fe50be5d3cbf5fb00548d2b26e779c607dfd2dc69a7",
     "zh:1850b8f2e729553ba8b96d69dce035b814ce959c6805c25484f407c4e720c497",
     "zh:1ec76814a99461cd79ee4c879ed455ab338a3cb9e63fbe9308f91b5515e72e42",
@@ -63,6 +68,7 @@ provider "registry.terraform.io/hashicorp/http" {
   version     = "3.4.2"
   constraints = "3.4.2"
   hashes = [
+    "h1:eqo0hkFNrixeaT93PC5NiU893s7rUwwOMeqnCjjj3u0=",
     "h1:vaoPfsLm6mOk6avKTrWi35o+9p4fEeZAY3hzYoXVTfo=",
     "zh:0ba051c9c8659ce0fec94a3d50926745f11759509c4d6de0ad5f5eb289f0edd9",
     "zh:23e6760e8406fef645913bf47bfab1ca984c1c5805d2bb0ef8310b16913d29cd",
@@ -84,6 +90,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   constraints = "2.30.0"
   hashes = [
     "h1:+Je5UPTWMmO4eG5ep1WfujkXQI9tDk0OsMU4olU76Bg=",
+    "h1:wRVWY3sK32BNInDOlQnoGSmL638f3jjLFypCAotwpc8=",
     "zh:06531333a72fe6d2829f37a328e08a3fc4ed66226344a003b62418a834ac6c69",
     "zh:34480263939ef5007ce65c9f4945df5cab363f91e5260ae552bcd9f2ffeed444",
     "zh:59e71f9177da570c33507c44828288264c082d512138c5755800f2cd706c62bc",


### PR DESCRIPTION
# Fixes for karpenter deploy

## First error:

```
Error: karpenter/private failed to create kubernetes rest client for update of resource: resource [karpenter.sh/v1/EC2NodeClass] isn't valid for cluster, check the APIVersion and Kind fields are valid

   with kubectl_manifest.ec2nodeclass_private[0],
   on main.tf line 71, in resource "kubectl_manifest" "ec2nodeclass_private":
   71: resource "kubectl_manifest" "ec2nodeclass_private" {
```

Solution: set `apiVersion: karpenter.k8s.aws/v1` for resources `kubectl_manifest`: `ec2nodeclass_private` and `ec2nodeclass_public` (file `terraform/modules/k8s-karpenter/main.tf`).

## Second error:

```
 Error: karpenter/default failed to run apply: error when creating "/tmp/879917200kubectl_manifest.yaml": NodePool.karpenter.sh "default" is invalid: [spec.disruption.consolidateAfter: Required value, spec.template.spec.nodeClassRef.group: Required value, spec.template.spec.nodeClassRef.kind: Required value, <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]

   with kubectl_manifest.nodepool["default"],
   on main.tf line 135, in resource "kubectl_manifest" "nodepool":
  135: resource "kubectl_manifest" "nodepool" {
```

Solution: Added fielsds `group` and `kind` for private and public NodePools (file `terragrunt/ACCOUNT_ID/us-east-1/demo/env.yaml`)

```yaml
        spec:
          nodeClassRef:
            group: karpenter.k8s.aws
            kind: EC2NodeClass
            name: public
```

## Third error:

```
 Error: karpenter/ci failed to run apply: error when creating "/tmp/969255726kubectl_manifest.yaml": NodePool.karpenter.sh "ci" is invalid: [spec.disruption.consolidateAfter: Required value, <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]

   with kubectl_manifest.nodepool["ci"],
   on main.tf line 135, in resource "kubectl_manifest" "nodepool":
  135: resource "kubectl_manifest" "nodepool" {
```

Solution: Added field `consolidateAfter: 1m` for private and public NodePools (file `terragrunt/ACCOUNT_ID/us-east-1/demo/env.yaml`)

```yaml
     disruption:
       consolidationPolicy: WhenEmptyOrUnderutilized
       consolidateAfter: 1m
```

## Last one:

I removed the unnecessary data block `data "aws_ecrpublic_authorization_token" "token" {}` and the fields from the `helm_release` resource: `repository_username = data.aws_ecrpublic_authorization_token.token.user_name` and `repository_password = data.aws_ecrpublic_authorization_token.token.password`. I tested these changes, and everything works perfectly.

I also updated the `locals` block for Karpenter. I set the `chart` value to `oci://public.ecr.aws/karpenter`/karpenter and left the `repository` field empty. 

```
    chart         = try(var.helm.chart_name, "oci://public.ecr.aws/karpenter/karpenter")
    repository    = try(var.helm.repository, "")
```

This configuration has been tested across different Helm releases using OCI repositories, and everything works flawlessly. I successfully tested the Karpenter deployment from a Docker container in our sandbox account, and it was deployed without any issues.

There was another issue related to the `aws_ecrpublic_authorization_token`, related to aws provider. Since the public ECR is located in the `us-east-1` region, this data doesn't work in other regions. An additional AWS provider with an alias is required to handle this.